### PR TITLE
[PR] 대시보드 그래프 데이터 저장을 위한 mongoDB 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,16 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
+    testImplementation 'io.projectreactor:reactor-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+//    testImplementation 'org.springframework.security:spring-security-test'
 
     // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -45,6 +47,10 @@ dependencies {
 
     // AOP
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // mongoDB
+    implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
     testImplementation 'io.projectreactor:reactor-test'
@@ -33,7 +33,7 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/org/omoknoone/ppm/PpmApplication.java
+++ b/src/main/java/org/omoknoone/ppm/PpmApplication.java
@@ -5,8 +5,10 @@ import org.modelmapper.config.Configuration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @SpringBootApplication
+@EnableMongoRepositories
 public class PpmApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/aggregate/ProjectDashboard.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/aggregate/ProjectDashboard.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 // mongoDB document
 @Document(collection = "ProjectDashboard")
@@ -22,6 +23,8 @@ public class ProjectDashboard {
 
 	private List<Map<String, Object>> series;
 
-	private Integer projectId;
+	private String projectId;
+
+	private String type;
 
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/aggregate/ProjectDashboard.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/aggregate/ProjectDashboard.java
@@ -1,0 +1,27 @@
+package org.omoknoone.ppm.projectDashboard.aggregate;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// mongoDB document
+@Document(collection = "ProjectDashboard")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectDashboard {
+
+	@Id
+	private String id;
+
+	private List<Map<String, Object>> series;
+
+	private Integer projectId;
+
+}

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/controller/ProjectDashboardController.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/controller/ProjectDashboardController.java
@@ -1,0 +1,33 @@
+package org.omoknoone.ppm.projectDashboard.controller;
+
+import java.util.List;
+
+import org.omoknoone.ppm.projectDashboard.aggregate.ProjectDashboard;
+import org.omoknoone.ppm.projectDashboard.service.ProjectDashboardService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/projectDashboards")
+public class ProjectDashboardController {
+
+	private final ProjectDashboardService projectDashboardService;
+
+	@Autowired
+	public ProjectDashboardController(ProjectDashboardService projectDashboardService) {
+		this.projectDashboardService = projectDashboardService;
+	}
+
+	@GetMapping("/{projectId}")
+	public List<ProjectDashboard> viewProjectDashboardByProjectId(@PathVariable String projectId) {
+
+		List<ProjectDashboard> projectDashboard = projectDashboardService.viewProjectDashboardByProjectId(projectId);
+
+		return ResponseEntity.ok(projectDashboard).getBody();
+	}
+
+}

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/controller/ProjectDashboardController.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/controller/ProjectDashboardController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +23,7 @@ public class ProjectDashboardController {
 		this.projectDashboardService = projectDashboardService;
 	}
 
+	// projectId로 graph에 들어갈 JSON 데이터 조회
 	@GetMapping("/{projectId}")
 	public List<ProjectDashboard> viewProjectDashboardByProjectId(@PathVariable String projectId) {
 
@@ -29,5 +31,15 @@ public class ProjectDashboardController {
 
 		return ResponseEntity.ok(projectDashboard).getBody();
 	}
+
+
+	// 게이지 업데이트 테스트용 (추후 삭제)
+	@GetMapping("/test/{projectId}")
+	public void testMethod(@PathVariable String projectId) {
+
+		projectDashboardService.updateGauge(projectId);
+
+	}
+
 
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/dto/ProjectDashboardDTO.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/dto/ProjectDashboardDTO.java
@@ -1,0 +1,4 @@
+package org.omoknoone.ppm.projectDashboard.dto;
+
+public class ProjectDashboardDTO {
+}

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/repository/ProjectDashboardRepository.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/repository/ProjectDashboardRepository.java
@@ -1,0 +1,17 @@
+package org.omoknoone.ppm.projectDashboard.repository;
+
+import java.util.List;
+
+import org.omoknoone.ppm.projectDashboard.aggregate.ProjectDashboard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectDashboardRepository extends MongoRepository<ProjectDashboard, String> {
+
+	@Query("{projectId :'?0'}")
+	List<ProjectDashboard> findAllByProjectId(String projectId);
+
+}

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/repository/ProjectDashboardRepository.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/repository/ProjectDashboardRepository.java
@@ -11,7 +11,21 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProjectDashboardRepository extends MongoRepository<ProjectDashboard, String> {
 
-	@Query("{projectId :'?0'}")
+	@Query("{'projectId' : ?0}")
 	List<ProjectDashboard> findAllByProjectId(String projectId);
+
+	ProjectDashboard findByProjectIdAndType(String projectId, String type);
+
+	// // 게이지 그래프 전체 진행률 데이터 업데이트
+	// @Query("{'projectId': ?0, 'type': 'gauge', 'series': {'$elemMatch': {'name': '전체진행률'}}}")
+	// void updateGaugeData(String projectId, Float newData);
+	//
+	// // 파이 그래프 업데이트
+	// @Query("{'projectId': ?0, 'type': 'pie', 'series': {'$elemMatch': {'name': { '$in': ['준비', '진행', '완료'] }}}}")
+	// void updatePieChartData(String projectId, Float newData);
+
+
+
+
 
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
@@ -1,0 +1,9 @@
+package org.omoknoone.ppm.projectDashboard.service;
+
+import java.util.List;
+
+import org.omoknoone.ppm.projectDashboard.aggregate.ProjectDashboard;
+
+public interface ProjectDashboardService {
+	List<ProjectDashboard> viewProjectDashboardByProjectId(String projectId);
+}

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
@@ -6,4 +6,6 @@ import org.omoknoone.ppm.projectDashboard.aggregate.ProjectDashboard;
 
 public interface ProjectDashboardService {
 	List<ProjectDashboard> viewProjectDashboardByProjectId(String projectId);
+	void updateGauge(String projectId);
+
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
@@ -25,8 +25,7 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 	private final ProjectDashboardRepository projectDashboardRepository;
 	private final ScheduleService scheduleService;
 
-	@Autowired
-	private MongoTemplate mongoTemplate;
+	private final MongoTemplate mongoTemplate;
 
 	// 프로젝트 Id를 통해 대시보드(그래프) 조회
 	public List<ProjectDashboard> viewProjectDashboardByProjectId(String projectId) {

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
@@ -4,10 +4,18 @@ import java.util.List;
 
 import org.omoknoone.ppm.projectDashboard.aggregate.ProjectDashboard;
 import org.omoknoone.ppm.projectDashboard.repository.ProjectDashboardRepository;
+import org.omoknoone.ppm.schedule.service.ScheduleService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.mongodb.core.query.Query;
+
 
 @Slf4j
 @Service
@@ -15,7 +23,12 @@ import lombok.extern.slf4j.Slf4j;
 public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 
 	private final ProjectDashboardRepository projectDashboardRepository;
+	private final ScheduleService scheduleService;
 
+	@Autowired
+	private MongoTemplate mongoTemplate;
+
+	// 프로젝트 Id를 통해 대시보드(그래프) 조회
 	public List<ProjectDashboard> viewProjectDashboardByProjectId(String projectId) {
 
 		List<ProjectDashboard> projectDashboard = projectDashboardRepository.findAllByProjectId(projectId);
@@ -25,4 +38,30 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 		// return projectDashboard;
 		return projectDashboard;
 	}
+
+
+	// 전체진행률 (게이지) 업데이트
+	public void updateGauge(String projectId) {
+
+		Criteria criteria = new Criteria().andOperator(
+			Criteria.where("projectId").is(projectId),
+			Criteria.where("type").is("gauge"),
+			Criteria.where("series.name").is("전체진행률")
+		);
+
+		Query query = new Query(criteria);
+
+		Update update = new Update();
+		update.set("series.$.data", 30);
+
+		mongoTemplate.updateMulti(
+			query,
+			update,
+			ProjectDashboard.class
+		);
+
+	}
+
+
+
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
@@ -1,0 +1,28 @@
+package org.omoknoone.ppm.projectDashboard.service;
+
+import java.util.List;
+
+import org.omoknoone.ppm.projectDashboard.aggregate.ProjectDashboard;
+import org.omoknoone.ppm.projectDashboard.repository.ProjectDashboardRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProjectDashboardServiceImpl implements ProjectDashboardService {
+
+	private final ProjectDashboardRepository projectDashboardRepository;
+
+	public List<ProjectDashboard> viewProjectDashboardByProjectId(String projectId) {
+
+		List<ProjectDashboard> projectDashboard = projectDashboardRepository.findAllByProjectId(projectId);
+
+		log.info("[serivce] {}", projectDashboard);
+
+		// return projectDashboard;
+		return projectDashboard;
+	}
+}

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/vo/ProjectDashboardVO.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/vo/ProjectDashboardVO.java
@@ -1,0 +1,4 @@
+package org.omoknoone.ppm.projectDashboard.vo;
+
+public class ProjectDashboardVO {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

> 그래프의 유형에 따라 필요한 데이터의 형태와 개수가 달라 JSON형식으로 저장하기 위해 mongoDB를 도입했습니다.
mongoDB Atlas를 이용하여 클라우드 환경으로 데이터베이스를 이용할 수 있습니다.
프로젝트Id를 통한 그래프 데이터 조회 및 gauge data update 까지 구현 후 postman 테스트 하였습니다.

### 📷스크린샷 (선택)

<img width="662" alt="image" src="https://github.com/OmokNoonE/PPM-backend/assets/80697609/32c61daf-5a38-46c8-96cb-086d7ca71be2">


## 💬리뷰 요구사항(선택)

> 
