### PR TITLE
[PR] 프로젝트 구성원 죄외(soft delete), 재활성화 기능 구현, 수정 기능 변수명 일부 수정

### DIFF
--- a/src/main/java/org/omoknoone/ppm/common/ResponseMessage.java
+++ b/src/main/java/org/omoknoone/ppm/common/ResponseMessage.java
@@ -13,10 +13,17 @@ public class ResponseMessage {
     private int httpStatus;                 // 상태코드
     private String message;                 // 응답 메세지
     private Map<String, Object> result;     // 응답 데이터
-    
+
     public ResponseMessage(int httpStatus, String message, Map<String, Object> result) {
         this.httpStatus = httpStatus;
         this.message = message;
         this.result = result;
+    }
+
+    // 상태와 메시지만을 포함하는 생성자
+    public ResponseMessage(int httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.result = null;  // 결과 필드를 명시적으로 null로 설정
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
@@ -67,4 +67,11 @@ public class ProjectMember {
         this.projectMemberExclusionDate = LocalDateTime.now();
     }
 
+    public void reactivate() {
+        if (!this.projectMemberIsExcluded) {
+            throw new IllegalStateException("이미 활성화된 구성원입니다. 다시 활성화할 수 없습니다.");
+        }
+        this.projectMemberIsExcluded = false;
+        this.projectMemberExclusionDate = null;
+    }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
@@ -23,14 +23,12 @@ public class ProjectMember {
     @Column(name = "project_member_created_date", nullable = false, length = 30)
     private LocalDateTime projectMemberCreatedDate;
 
-    @LastModifiedDate
     @Column(name = "project_member_modified_date", length = 30)
     private LocalDateTime projectMemberModifiedDate;
 
     @Column(name = "project_member_is_excluded", nullable = false)
     private Boolean projectMemberIsExcluded = false;
 
-    @LastModifiedDate
     @Column(name = "project_member_exclusion_date", length = 30)
     private LocalDateTime projectMemberExclusionDate;
 
@@ -52,15 +50,21 @@ public class ProjectMember {
         this.projectMemberProjectId = projectMemberProjectId;
         this.projectMemberRoleId = projectMemberRoleId;
         this.projectMemberEmployeeId = projectMemberEmployeeId;
-        this.projectMemberIsExcluded = projectMemberIsExcluded;
+        this.projectMemberIsExcluded
+                = projectMemberIsExcluded != null ? projectMemberIsExcluded : false; // null일 경우 기본값 false
         this.projectMemberExclusionDate = projectMemberExclusionDate;
         this.projectMemberCreatedDate = projectMemberCreatedDate;
         this.projectMemberModifiedDate = projectMemberModifiedDate;
     }
 
     public void modify(ModifyProjectMemberRequestDTO dto) {
-        this.projectMemberId = dto.getProjectMemberId();
         this.projectMemberRoleId = dto.getProjectMemberRoleId();
+        this.projectMemberModifiedDate = LocalDateTime.now();
+    }
+
+    public void remove() {
+        this.projectMemberIsExcluded = true;
+        this.projectMemberExclusionDate = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
@@ -36,12 +36,12 @@ public class ProjectMemberController {
                 = projectMemberService.viewProjectMembersByProject(projectId);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("특정 프로젝트 구성원 목록", responseDTOs);
+        responseMap.put("프로젝트 구성원 목록", responseDTOs);
 
         return ResponseEntity
                 .ok()
                 .headers(headers)
-                .body(new ResponseMessage(200, "ok", responseMap));
+                .body(new ResponseMessage(200, "프로젝트 구성원 조회 성공", responseMap));
     }
 
     @PostMapping("/create")
@@ -57,7 +57,7 @@ public class ProjectMemberController {
         return ResponseEntity
                 .ok()
                 .headers(headers)
-                .body(new ResponseMessage(200, "성공적으로 구성원이 추가되었습니다.", responseMap));
+                .body(new ResponseMessage(200, "성공적으로 구성원이 추가 완료.", responseMap));
     }
 
     @DeleteMapping("/remove/{projectMemberId}")
@@ -73,11 +73,36 @@ public class ProjectMemberController {
             return ResponseEntity
                     .ok()
                     .headers(headers)
-                    .body(new ResponseMessage(200, "구성원 제외가 완료되었습니다.", responseMap));
-        } catch (EntityNotFoundException e) {
+                    .body(new ResponseMessage(200, "구성원 제외가 완료.", responseMap));
+        } catch (EntityNotFoundException ex) {
             return ResponseEntity
                     .status(HttpStatus.NOT_FOUND)
-                    .body(new ResponseMessage(404, "구성원을 찾을 수 없습니다."));
+                    .body(new ResponseMessage(404, "구성원을 찾을 수 없음."));
+        }
+    }
+
+    @PutMapping("/reactivate/{projectMemberId}")
+    public ResponseEntity<ResponseMessage> reactivateProjectMember(@PathVariable Integer projectMemberId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+
+        try {
+            projectMemberService.reactivateProjectMember(projectMemberId);
+            Map<String, Object> responseMap = new HashMap<>();
+            responseMap.put("재활성화된 프로젝트 멤버 ID", projectMemberId);
+
+            return ResponseEntity
+                    .ok()
+                    .headers(headers)
+                    .body(new ResponseMessage(200, "구성원 활성화가 완료.", responseMap));
+        } catch (EntityNotFoundException ex) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(new ResponseMessage(404, "구성원을 찾을 수 없음."));
+        } catch (IllegalStateException ex) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseMessage(400, "이미 활성화된 구성원입니다. 다시 활성화할 수 없습니다."));
         }
     }
 
@@ -95,12 +120,11 @@ public class ProjectMemberController {
             return ResponseEntity
                     .ok()
                     .headers(headers)
-                    .body(new ResponseMessage(200, "구성원의 권한 수정이 완료되었습니다.", responseMap));
-        } catch (EntityNotFoundException e) {
-            log.error("Error modifying project member: {}", e.getMessage());
+                    .body(new ResponseMessage(200, "구성원의 권한 수정이 완료.", responseMap));
+        } catch (EntityNotFoundException ex) {
             return ResponseEntity
                     .status(HttpStatus.NOT_FOUND)
-                    .body(new ResponseMessage(404, "구성원을 찾을 수 없습니다.", null));
+                    .body(new ResponseMessage(404, "구성원을 찾을 수 없음."));
         }
     }
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
@@ -60,6 +60,27 @@ public class ProjectMemberController {
                 .body(new ResponseMessage(200, "성공적으로 구성원이 추가되었습니다.", responseMap));
     }
 
+    @DeleteMapping("/remove/{projectMemberId}")
+    public ResponseEntity<ResponseMessage> removeProjectMember(@PathVariable Integer projectMemberId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+
+        try {
+            projectMemberService.removeProjectMember(projectMemberId);
+            Map<String, Object> responseMap = new HashMap<>();
+            responseMap.put("제외된 프로젝트 멤버 ID", projectMemberId);
+
+            return ResponseEntity
+                    .ok()
+                    .headers(headers)
+                    .body(new ResponseMessage(200, "구성원 제외가 완료되었습니다.", responseMap));
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(new ResponseMessage(404, "구성원을 찾을 수 없습니다."));
+        }
+    }
+
     @PutMapping("/modify")
     public ResponseEntity<ResponseMessage> modifyProjectMember(@RequestBody ModifyProjectMemberRequestDTO requestDTO) {
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
@@ -11,7 +11,7 @@ public interface ProjectMemberService {
 
     Integer createProjectMember(CreateProjectMemberRequestDTO createProjectMemberRequestDTO);
 
-    String removeProjectMember(Integer projectMemberId);
+    void removeProjectMember(Integer projectMemberId);
 
     Integer modifyProjectMember(ModifyProjectMemberRequestDTO modifyProjectMemberRequestDTO);
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
@@ -13,6 +13,8 @@ public interface ProjectMemberService {
 
     void removeProjectMember(Integer projectMemberId);
 
+    void reactivateProjectMember(Integer projectMemberId);
+
     Integer modifyProjectMember(ModifyProjectMemberRequestDTO modifyProjectMemberRequestDTO);
 
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
@@ -40,17 +40,21 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
     @Transactional
     @Override
     public Integer createProjectMember(CreateProjectMemberRequestDTO dto) {
-        ProjectMember member = modelMapper.map(dto, ProjectMember.class);
+        ProjectMember newMember = modelMapper.map(dto, ProjectMember.class);
 
-        projectMemberRepository.save(member);
+        projectMemberRepository.save(newMember);
 
-        return member.getProjectMemberId();
+        return newMember.getProjectMemberId();
     }
 
     @Transactional
     @Override
-    public String removeProjectMember(Integer projectMemberId) {
-        return null;
+    public void removeProjectMember(Integer projectMemberId) {
+        ProjectMember excludedMember = projectMemberRepository.findById(projectMemberId)
+                .orElseThrow(() -> new EntityNotFoundException("exception.data.entityNotFound"));
+        excludedMember.remove();
+
+        projectMemberRepository.save(excludedMember);
     }
 
     @Transactional

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
@@ -57,6 +57,15 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
         projectMemberRepository.save(excludedMember);
     }
 
+    @Override
+    public void reactivateProjectMember(Integer projectMemberId) {
+        ProjectMember reactivatedMember = projectMemberRepository.findById(projectMemberId)
+                .orElseThrow(() -> new EntityNotFoundException("exception.data.entityNotFound"));
+        reactivatedMember.reactivate();
+
+        projectMemberRepository.save(reactivatedMember);
+    }
+
     @Transactional
     @Override
     public Integer modifyProjectMember(ModifyProjectMemberRequestDTO dto) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #15 

## 📝작업 내용

> 프로젝트 구성원을 제외 하는 기능을 구현하였습니다. soft delete로 제외된 구성원은 비활성화가 됩니다. 프로젝트 구성원 수정 기능의 일부 변수명들을 가독성을 높이기 위해서 변경하였습니다.

추가적으로 제외되어 비활성화된 회원의 활성화 메소드가 필요할 것 같아 추가할 예정입니다. 

## 💬리뷰 요구사항(선택)

> reactivate ~~ 시작하는 메소드로 만들려고 하는데 의견을 알려주세요!
