### PR TITLE
[PR] 대시보드 그래프 데이터 업데이트 기능 구현

### DIFF
--- a/src/main/java/org/omoknoone/ppm/projectDashboard/aggregate/ProjectDashboard.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/aggregate/ProjectDashboard.java
@@ -1,5 +1,6 @@
 package org.omoknoone.ppm.projectDashboard.aggregate;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -26,5 +27,7 @@ public class ProjectDashboard {
 	private String projectId;
 
 	private String type;
+
+	private List<String> categories;
 
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/controller/ProjectDashboardController.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/controller/ProjectDashboardController.java
@@ -3,6 +3,7 @@ package org.omoknoone.ppm.projectDashboard.controller;
 import java.util.List;
 
 import org.omoknoone.ppm.projectDashboard.aggregate.ProjectDashboard;
+import org.omoknoone.ppm.projectDashboard.dto.ProjectDashboardDTO;
 import org.omoknoone.ppm.projectDashboard.service.ProjectDashboardService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -25,9 +26,9 @@ public class ProjectDashboardController {
 
 	// projectId로 graph에 들어갈 JSON 데이터 조회
 	@GetMapping("/{projectId}")
-	public List<ProjectDashboard> viewProjectDashboardByProjectId(@PathVariable String projectId) {
+	public List<ProjectDashboardDTO> viewProjectDashboardByProjectId(@PathVariable String projectId) {
 
-		List<ProjectDashboard> projectDashboard = projectDashboardService.viewProjectDashboardByProjectId(projectId);
+		List<ProjectDashboardDTO> projectDashboard = projectDashboardService.viewProjectDashboardByProjectId(projectId);
 
 		return ResponseEntity.ok(projectDashboard).getBody();
 	}

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/dto/ProjectDashboardDTO.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/dto/ProjectDashboardDTO.java
@@ -1,4 +1,33 @@
 package org.omoknoone.ppm.projectDashboard.dto;
 
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@ToString
 public class ProjectDashboardDTO {
+
+	private String id;
+
+	private List<Map<String, Object>> series;
+
+	private String projectId;
+
+	private String type;
+
+	@Builder
+	public ProjectDashboardDTO(String id, List<Map<String, Object>> series, String projectId, String type) {
+		this.id = id;
+		this.series = series;
+		this.projectId = projectId;
+		this.type = type;
+	}
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/repository/ProjectDashboardRepository.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/repository/ProjectDashboardRepository.java
@@ -24,7 +24,7 @@ public interface ProjectDashboardRepository extends MongoRepository<ProjectDashb
 	// @Query("{'projectId': ?0, 'type': 'pie', 'series': {'$elemMatch': {'name': { '$in': ['준비', '진행', '완료'] }}}}")
 	// void updatePieChartData(String projectId, Float newData);
 
-
+	ProjectDashboard findAllByProjectIdAndType(String projectId, String type);
 
 
 

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
@@ -3,9 +3,10 @@ package org.omoknoone.ppm.projectDashboard.service;
 import java.util.List;
 
 import org.omoknoone.ppm.projectDashboard.aggregate.ProjectDashboard;
+import org.omoknoone.ppm.projectDashboard.dto.ProjectDashboardDTO;
 
 public interface ProjectDashboardService {
-	List<ProjectDashboard> viewProjectDashboardByProjectId(String projectId);
+	List<ProjectDashboardDTO> viewProjectDashboardByProjectId(String projectId);
 	void updateGauge(String projectId);
-
+	void updatePie(String projectId, String type);
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
@@ -10,4 +10,6 @@ public interface ProjectDashboardService {
 	void updateGauge(String projectId);
 	void updatePie(String projectId, String type);
 	void updateTable(String projectId, String type);
+
+	void updateColumn(String projectId, String type);
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
@@ -9,4 +9,5 @@ public interface ProjectDashboardService {
 	List<ProjectDashboardDTO> viewProjectDashboardByProjectId(String projectId);
 	void updateGauge(String projectId);
 	void updatePie(String projectId, String type);
+	void updateTable(String projectId, String type);
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardService.java
@@ -12,4 +12,5 @@ public interface ProjectDashboardService {
 	void updateTable(String projectId, String type);
 
 	void updateColumn(String projectId, String type);
+	void updateLine(String projectId, String type);
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
@@ -1,6 +1,7 @@
 package org.omoknoone.ppm.projectDashboard.service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,6 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 
 		// example data
 		// projectId = 1, type = table
-
 		ProjectDashboard projectDashboard = projectDashboardRepository.findAllByProjectIdAndType(projectId, type);
 		List<Map<String, Object>> series = projectDashboard.getSeries();
 
@@ -108,9 +108,48 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 			}
 		}
 
-		projectDashboardRepository.save(projectDashboard).getSeries();
+		projectDashboardRepository.save(projectDashboard);
 
 	}
 
+	// column
+	public void updateColumn(String projectId, String type) {
+
+		ProjectDashboard projectDashboard = projectDashboardRepository.findAllByProjectIdAndType(projectId, type);
+		List<String> categories = projectDashboard.getCategories();
+		List<Map<String, Object>> series = projectDashboard.getSeries();
+
+		// update할 categoreis (section명들)
+		List<String> updateCategories = Arrays.asList("섹션명1", "섹션명2", "섹션명3");
+
+		// update할 section별 진행상황
+		Map<String, List<Integer>> updates = Map.of(
+			"준비", List.of(1, 1, 1),
+			"진행", List.of(2, 2, 2),
+			"완료", List.of(3, 3, 3)
+		);
+
+		// categories를 업데이트
+		projectDashboard.getCategories().clear(); // 기존 카테고리를 모두 지우고
+		projectDashboard.getCategories().addAll(updateCategories); // 새로운 카테고리로 대체
+
+		// 각 상태(준비, 진행, 완료)에 대한 값을 업데이트
+		for (Map.Entry<String, List<Integer>> entry : updates.entrySet()) {
+			String status = entry.getKey();
+			List<Integer> values = entry.getValue();
+
+			// 현재 상태에 대한 값을 업데이트
+			for (Map<String, Object> seriesItem : series) {
+				if (seriesItem.get("name").equals(status)) {
+					seriesItem.put("data", values);
+					break; // 해당 상태에 대한 값 업데이트 후 루프 종료
+				}
+			}
+		}
+
+		// 업데이트된 데이터를 저장
+		projectDashboardRepository.save(projectDashboard);
+
+	}
 
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
@@ -152,4 +152,56 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 
 	}
 
+	// line
+	public void updateLine(String projectId, String type) {
+
+		ProjectDashboard projectDashboard = projectDashboardRepository.findAllByProjectIdAndType(projectId, type);
+		List<String> categories = projectDashboard.getCategories();
+		List<Map<String, Object>> series = projectDashboard.getSeries();
+
+		// update할 categoreis (날짜)
+		List<String> updateCategories = Arrays.asList(
+			"01/02/2023",
+			"02/02/2023",
+			"03/02/2023",
+			"04/02/2023",
+			"05/02/2023",
+			"06/02/2023",
+			"07/02/2023",
+			"08/02/2023",
+			"09/02/2023",
+			"10/02/2023",
+			"11/02/2023",
+			"12/02/2023"
+		);
+
+		// update할 section별 진행상황
+		Map<String, List<Integer>> updates = Map.of(
+			"예상진행률", Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5),
+			"실제진행률", Arrays.asList(4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4)
+		);
+
+
+		// categories update
+		projectDashboard.getCategories().clear(); // 기존 카테고리를 모두 지우고
+		projectDashboard.getCategories().addAll(updateCategories); // 새로운 카테고리로 대체
+
+		// data update
+		for (Map.Entry<String, List<Integer>> entry : updates.entrySet()) {
+			String status = entry.getKey();
+			List<Integer> values = entry.getValue();
+
+			for (Map<String, Object> seriesItem : series) {
+				if (seriesItem.get("name").equals(status)) {
+					seriesItem.put("data", values);
+					break; // 해당 상태에 대한 값 업데이트 후 루프 종료
+				}
+			}
+		}
+
+		projectDashboardRepository.save(projectDashboard);
+
+	}
+
+
 }

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
@@ -78,8 +78,7 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 			projectDashboard.getSeries().set(i, data);
 		}
 
-		List<Map<String, Object>> mapList = projectDashboardRepository.save(projectDashboard).getSeries();
-		System.out.println("mapList = " + mapList);
+		projectDashboardRepository.save(projectDashboard);
 
 	}
 

--- a/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/projectDashboard/service/ProjectDashboardServiceImpl.java
@@ -1,5 +1,6 @@
 package org.omoknoone.ppm.projectDashboard.service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,35 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 
 	}
 
+	// table (구성원별 진행상태)
+	public void updateTable(String projectId, String type) {
+
+		// example data
+		// projectId = 1, type = table
+
+		ProjectDashboard projectDashboard = projectDashboardRepository.findAllByProjectIdAndType(projectId, type);
+		List<Map<String, Object>> series = projectDashboard.getSeries();
+
+		// update 할 data를 담고 있는 Map
+		Map<String, Map<String, Integer>> updates = Map.of(
+			"조예린", Map.of("준비", 55, "진행", 55, "완료", 55),
+			"오목이", Map.of("준비", 3, "진행", 2, "완료", 1)
+		);
+
+		// 새로운 값으로 update
+		for(Map<String, Object> data : series) {
+			String memberName = (String)data.get("구성원명");
+			if(updates.containsKey(memberName)) {
+				Map<String, Integer> memberUpdates = updates.get(memberName);
+				for(Map.Entry<String, Integer> entry : memberUpdates.entrySet()) {
+					data.put(entry.getKey(), entry.getValue());
+				}
+			}
+		}
+
+		projectDashboardRepository.save(projectDashboard).getSeries();
+
+	}
 
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#25 #60 

## 📝작업 내용

> 프로젝트 ID를 기준으로 대시보드에 표시할 그래프 데이터를 조회하는 기능과, 각 그래프의 유형에 따라 프로젝트 ID를 통해 해당 프로젝트의 MongoDB 그래프 데이터를 업데이트하는 기능을 구현했습니다. 현재는 리터럴 값으로 입력된 예시 데이터 대신, 진행률을 계산하는 메소드의 반환값을 사용하면 됩니다.


### 📷스크린샷 (선택)



## 💬리뷰 요구사항(선택)

