### PR TITLE
[PR] collection/table명 중복에 따라 이름 변경

### DIFF
--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/aggregate/Graph.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/aggregate/Graph.java
@@ -1,6 +1,5 @@
 package org.omoknoone.ppm.domain.projectDashboard.aggregate;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -10,14 +9,13 @@ import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 // mongoDB document
-@Document(collection = "ProjectDashboard")
+@Document(collection = "Graph")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProjectDashboard {
+public class Graph {
 
 	@Id
 	private String id;

--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/controller/GraphController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/controller/GraphController.java
@@ -2,9 +2,8 @@ package org.omoknoone.ppm.domain.projectDashboard.controller;
 
 import java.util.List;
 
-import org.omoknoone.ppm.domain.projectDashboard.dto.ProjectDashboardDTO;
-import org.omoknoone.ppm.domain.projectDashboard.service.ProjectDashboardService;
-import org.omoknoone.ppm.domain.projectDashboard.aggregate.ProjectDashboard;
+import org.omoknoone.ppm.domain.projectDashboard.dto.GraphDTO;
+import org.omoknoone.ppm.domain.projectDashboard.service.GraphService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,21 +12,21 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/projectDashboards")
-public class ProjectDashboardController {
+@RequestMapping("/graphs")
+public class GraphController {
 
-	private final ProjectDashboardService projectDashboardService;
+	private final GraphService graphService;
 
 	@Autowired
-	public ProjectDashboardController(ProjectDashboardService projectDashboardService) {
-		this.projectDashboardService = projectDashboardService;
+	public GraphController(GraphService graphService) {
+		this.graphService = graphService;
 	}
 
 	// projectId로 graph에 들어갈 JSON 데이터 조회
 	@GetMapping("/{projectId}")
-	public List<ProjectDashboardDTO> viewProjectDashboardByProjectId(@PathVariable String projectId) {
+	public List<GraphDTO> viewProjectDashboardByProjectId(@PathVariable String projectId) {
 
-		List<ProjectDashboardDTO> projectDashboard = projectDashboardService.viewProjectDashboardByProjectId(projectId);
+		List<GraphDTO> projectDashboard = graphService.viewProjectDashboardByProjectId(projectId);
 
 		return ResponseEntity.ok(projectDashboard).getBody();
 	}
@@ -37,7 +36,7 @@ public class ProjectDashboardController {
 	@GetMapping("/test/{projectId}")
 	public void testMethod(@PathVariable String projectId) {
 
-		projectDashboardService.updateGauge(projectId);
+		graphService.updateGauge(projectId);
 
 	}
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/dto/GraphDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/dto/GraphDTO.java
@@ -3,17 +3,15 @@ package org.omoknoone.ppm.domain.projectDashboard.dto;
 import java.util.List;
 import java.util.Map;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 @NoArgsConstructor
 @Getter
 @ToString
-public class ProjectDashboardDTO {
+public class GraphDTO {
 
     private String id;
 
@@ -24,7 +22,7 @@ public class ProjectDashboardDTO {
     private String type;
 
     @Builder
-    public ProjectDashboardDTO(String id, List<Map<String, Object>> series, String projectId, String type) {
+    public GraphDTO(String id, List<Map<String, Object>> series, String projectId, String type) {
         this.id = id;
         this.series = series;
         this.projectId = projectId;

--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/repository/GraphRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/repository/GraphRepository.java
@@ -2,18 +2,18 @@ package org.omoknoone.ppm.domain.projectDashboard.repository;
 
 import java.util.List;
 
-import org.omoknoone.ppm.domain.projectDashboard.aggregate.ProjectDashboard;
+import org.omoknoone.ppm.domain.projectDashboard.aggregate.Graph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProjectDashboardRepository extends MongoRepository<ProjectDashboard, String> {
+public interface GraphRepository extends MongoRepository<Graph, String> {
 
 	@Query("{'projectId' : ?0}")
-	List<ProjectDashboard> findAllByProjectId(String projectId);
+	List<Graph> findAllByProjectId(String projectId);
 
-	ProjectDashboard findByProjectIdAndType(String projectId, String type);
+	Graph findByProjectIdAndType(String projectId, String type);
 
 	// // 게이지 그래프 전체 진행률 데이터 업데이트
 	// @Query("{'projectId': ?0, 'type': 'gauge', 'series': {'$elemMatch': {'name': '전체진행률'}}}")
@@ -23,7 +23,7 @@ public interface ProjectDashboardRepository extends MongoRepository<ProjectDashb
 	// @Query("{'projectId': ?0, 'type': 'pie', 'series': {'$elemMatch': {'name': { '$in': ['준비', '진행', '완료'] }}}}")
 	// void updatePieChartData(String projectId, Float newData);
 
-	ProjectDashboard findAllByProjectIdAndType(String projectId, String type);
+	Graph findAllByProjectIdAndType(String projectId, String type);
 
 
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/service/GraphService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/service/GraphService.java
@@ -2,11 +2,10 @@ package org.omoknoone.ppm.domain.projectDashboard.service;
 
 import java.util.List;
 
-import org.omoknoone.ppm.domain.projectDashboard.aggregate.ProjectDashboard;
-import org.omoknoone.ppm.domain.projectDashboard.dto.ProjectDashboardDTO;
+import org.omoknoone.ppm.domain.projectDashboard.dto.GraphDTO;
 
-public interface ProjectDashboardService {
-	List<ProjectDashboardDTO> viewProjectDashboardByProjectId(String projectId);
+public interface GraphService {
+	List<GraphDTO> viewProjectDashboardByProjectId(String projectId);
 	void updateGauge(String projectId);
 	void updatePie(String projectId, String type);
 	void updateTable(String projectId, String type);

--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/service/GraphServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/service/GraphServiceImpl.java
@@ -1,6 +1,5 @@
 package org.omoknoone.ppm.domain.projectDashboard.service;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -8,9 +7,9 @@ import java.util.Map;
 
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
-import org.omoknoone.ppm.domain.projectDashboard.aggregate.ProjectDashboard;
-import org.omoknoone.ppm.domain.projectDashboard.dto.ProjectDashboardDTO;
-import org.omoknoone.ppm.domain.projectDashboard.repository.ProjectDashboardRepository;
+import org.omoknoone.ppm.domain.projectDashboard.aggregate.Graph;
+import org.omoknoone.ppm.domain.projectDashboard.dto.GraphDTO;
+import org.omoknoone.ppm.domain.projectDashboard.repository.GraphRepository;
 import org.omoknoone.ppm.domain.schedule.service.ScheduleService;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -25,19 +24,24 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ProjectDashboardServiceImpl implements ProjectDashboardService {
+public class GraphServiceImpl implements GraphService {
 
-    private final ProjectDashboardRepository projectDashboardRepository;
+    private final GraphRepository graphRepository;
     private final ScheduleService scheduleService;
     private final MongoTemplate mongoTemplate;
     private final ModelMapper modelMapper;
 
+    // init
+    // 프로젝트가 생성될 때 대시보드가 초기값으로 생성 되어야함
+    public void initDashboard(String projectId) {
+    }
+
 
     // 프로젝트 Id를 통해 대시보드(그래프) 조회
-    public List<ProjectDashboardDTO> viewProjectDashboardByProjectId(String projectId) {
+    public List<GraphDTO> viewProjectDashboardByProjectId(String projectId) {
 
-        List<ProjectDashboard> projectDashboards = projectDashboardRepository.findAllByProjectId(projectId);
-        return modelMapper.map(projectDashboards, new TypeToken<List<ProjectDashboard>>() {
+        List<Graph> graphs = graphRepository.findAllByProjectId(projectId);
+        return modelMapper.map(graphs, new TypeToken<List<Graph>>() {
         }.getType());
     }
 
@@ -54,12 +58,12 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
         Query query = new Query(criteria);
 
         Update update = new Update();
-        update.set("series.$.data", 30);
+        update.set("series.$.data", 55);
 
         mongoTemplate.updateMulti(
                 query,
                 update,
-                ProjectDashboard.class
+                Graph.class
         );
 
     }
@@ -68,16 +72,16 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
     public void updatePie(String projectId, String type) {
         int[] datas = new int[]{10, 30, 50};
 
-        ProjectDashboard projectDashboard = projectDashboardRepository.findAllByProjectIdAndType(projectId, type);
+        Graph graph = graphRepository.findAllByProjectIdAndType(projectId, type);
 
         for (int i = 0; i < datas.length; i++) {
             Map<String, Object> data = new HashMap<>();
-            data.put("name", projectDashboard.getSeries().get(i).get("name"));
+            data.put("name", graph.getSeries().get(i).get("name"));
             data.put("data", datas[i]);
-            projectDashboard.getSeries().set(i, data);
+            graph.getSeries().set(i, data);
         }
 
-        projectDashboardRepository.save(projectDashboard);
+        graphRepository.save(graph);
 
     }
 
@@ -86,8 +90,8 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 
         // example data
         // projectId = 1, type = table
-        ProjectDashboard projectDashboard = projectDashboardRepository.findAllByProjectIdAndType(projectId, type);
-        List<Map<String, Object>> series = projectDashboard.getSeries();
+        Graph graph = graphRepository.findAllByProjectIdAndType(projectId, type);
+        List<Map<String, Object>> series = graph.getSeries();
 
         // update 할 data를 담고 있는 Map
         Map<String, Map<String, Integer>> updates = Map.of(
@@ -106,16 +110,16 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
             }
         }
 
-        projectDashboardRepository.save(projectDashboard);
+        graphRepository.save(graph);
 
     }
 
     // column
     public void updateColumn(String projectId, String type) {
 
-        ProjectDashboard projectDashboard = projectDashboardRepository.findAllByProjectIdAndType(projectId, type);
-        List<String> categories = projectDashboard.getCategories();
-        List<Map<String, Object>> series = projectDashboard.getSeries();
+        Graph graph = graphRepository.findAllByProjectIdAndType(projectId, type);
+        List<String> categories = graph.getCategories();
+        List<Map<String, Object>> series = graph.getSeries();
 
         // update할 categoreis (section명들)
         List<String> updateCategories = Arrays.asList("섹션명1", "섹션명2", "섹션명3");
@@ -128,8 +132,8 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
         );
 
         // categories를 업데이트
-        projectDashboard.getCategories().clear(); // 기존 카테고리를 모두 지우고
-        projectDashboard.getCategories().addAll(updateCategories); // 새로운 카테고리로 대체
+        graph.getCategories().clear(); // 기존 카테고리를 모두 지우고
+        graph.getCategories().addAll(updateCategories); // 새로운 카테고리로 대체
 
         // 각 상태(준비, 진행, 완료)에 대한 값을 업데이트
         for (Map.Entry<String, List<Integer>> entry : updates.entrySet()) {
@@ -146,16 +150,16 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
         }
 
         // 업데이트된 데이터를 저장
-        projectDashboardRepository.save(projectDashboard);
+        graphRepository.save(graph);
 
     }
 
     // line
     public void updateLine(String projectId, String type) {
 
-        ProjectDashboard projectDashboard = projectDashboardRepository.findAllByProjectIdAndType(projectId, type);
-        List<String> categories = projectDashboard.getCategories();
-        List<Map<String, Object>> series = projectDashboard.getSeries();
+        Graph graph = graphRepository.findAllByProjectIdAndType(projectId, type);
+        List<String> categories = graph.getCategories();
+        List<Map<String, Object>> series = graph.getSeries();
 
         // update할 categoreis (날짜)
         List<String> updateCategories = Arrays.asList(
@@ -181,8 +185,8 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
 
 
         // categories update
-        projectDashboard.getCategories().clear(); // 기존 카테고리를 모두 지우고
-        projectDashboard.getCategories().addAll(updateCategories); // 새로운 카테고리로 대체
+        graph.getCategories().clear(); // 기존 카테고리를 모두 지우고
+        graph.getCategories().addAll(updateCategories); // 새로운 카테고리로 대체
 
         // data update
         for (Map.Entry<String, List<Integer>> entry : updates.entrySet()) {
@@ -197,7 +201,7 @@ public class ProjectDashboardServiceImpl implements ProjectDashboardService {
             }
         }
 
-        projectDashboardRepository.save(projectDashboard);
+        graphRepository.save(graph);
 
     }
 


### PR DESCRIPTION
mongoDB와 mariaDB의 collection명과 table명이 중복되므로 mongoDB data를 Graph로 일괄 변경함

## #️⃣연관된 이슈

> - #84

## 📝작업 내용

> 기존의 ProjectDashboard -> Graph로 변경함

### 📷스크린샷 (선택)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
