### PR TITLE
[PR] 일정 상태값에 따른 필터링 기능 구현

### DIFF
--- a/src/main/java/org/omoknoone/ppm/domain/requirements/controller/RequirementsController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/requirements/controller/RequirementsController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -153,11 +154,23 @@ public class ScheduleController {
             .body(new ResponseMessage(204, "일정 삭제 성공", responseMap));
     }
 
-    /* 일정 검색 */
+    /* Title을 통한 일정 검색 */
     @GetMapping("/search/{scheduleTitle}")
     public ResponseEntity<ResponseSearchScheduleList> searchScheduleByTitle(@PathVariable String scheduleTitle){
         List<SearchScheduleListDTO> searchScheduleListDTO = scheduleService.searchSchedulesByTitle(scheduleTitle);
         ResponseSearchScheduleList searchResult = new ResponseSearchScheduleList(searchScheduleListDTO);
         return ResponseEntity.ok(searchResult);
+    }
+
+    /* 일정 상태값이 1개일 때 일정 목록 확인 */
+    @GetMapping("/status/{codeId}")
+    public List<Schedule> getSchedulesByStatusCode(@PathVariable Long codeId) {
+        return scheduleService.getSchedulesByStatusCode(codeId);
+    }
+
+    /* 일정 상태값이 2개 이상일 때 일정 목록 확인 */
+    @GetMapping("/statuses")
+    public List<Schedule> getSchedulesByStatusCodes(@RequestParam List<Long> codeIds) {
+        return scheduleService.getSchedulesByStatusCodes(codeIds);
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
@@ -162,14 +162,8 @@ public class ScheduleController {
         return ResponseEntity.ok(searchResult);
     }
 
-    /* 일정 상태값이 1개일 때 일정 목록 확인 */
-    @GetMapping("/status/{codeId}")
-    public List<Schedule> getSchedulesByStatusCode(@PathVariable Long codeId) {
-        return scheduleService.getSchedulesByStatusCode(codeId);
-    }
-
-    /* 일정 상태값이 2개 이상일 때 일정 목록 확인 */
-    @GetMapping("/statuses")
+    /* 일정 상태값에 따른 일정 목록 확인 */
+    @GetMapping("/status")
     public List<Schedule> getSchedulesByStatusCodes(@RequestParam List<Long> codeIds) {
         return scheduleService.getSchedulesByStatusCodes(codeIds);
     }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
@@ -42,7 +42,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findSchedulesByScheduleParentScheduleId(Long scheduleId);
 
-    /* 일정 검색 */
+    /* Title을 통한 일정 검색 */
     @Query("SELECT" + " new org.omoknoone.ppm.domain.schedule.dto.SearchScheduleListDTO" +
         "(a.scheduleId, a.scheduleTitle, a.scheduleContent, a.scheduleStartDate"
         + ", a.scheduleEndDate, a.scheduleProgress, a.scheduleStatus) " +
@@ -88,4 +88,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         + "    pm.projectMemberId ")
     List<UpdateTableDataDTO> UpdateTableData(Long projectId);
 
+    /* 일정 상태값이 1개일 때 일정 목록 확인 */
+    List<Schedule> findByScheduleStatus(Long codeId);
+
+    /* 일정 상태값이 2개 이상일 때 일정 목록 확인 */
+    List<Schedule> findByScheduleStatusIn(List<Long> codeIds);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
@@ -88,9 +88,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         + "    pm.projectMemberId ")
     List<UpdateTableDataDTO> UpdateTableData(Long projectId);
 
-    /* 일정 상태값이 1개일 때 일정 목록 확인 */
-    List<Schedule> findByScheduleStatus(Long codeId);
-
-    /* 일정 상태값이 2개 이상일 때 일정 목록 확인 */
+    /* 일정 상태값에 따른 일정 목록 확인 */
     List<Schedule> findByScheduleStatusIn(List<Long> codeIds);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
@@ -45,6 +45,7 @@ public interface ScheduleService {
     /* 업무 일정인지 확인 */
     boolean isTaskSchedule(Long scheduleId);
 
+    /* Title을 통한 일정 검색 */
     List<SearchScheduleListDTO> searchSchedulesByTitle(String scheduleTitle);
 
     /* 설명. 대시보드 게이지 제공 데이터 추출 */
@@ -59,4 +60,11 @@ public interface ScheduleService {
     /* 설명. 대시보드 컬럼 제공 데이터 추출 */
 
     /* 설명. 대시보드 라인 제공 데이터 추출 */
+
+    /* 상태 코드가 1개일 때 해당 일정 확인 */
+    List<Schedule> getSchedulesByStatusCode(Long codeId);
+
+    /* 상태 코드가 2개 이상일 때 해당 일정 확인 */
+    List<Schedule> getSchedulesByStatusCodes(List<Long> codeIds);
+
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
@@ -61,10 +61,7 @@ public interface ScheduleService {
 
     /* 설명. 대시보드 라인 제공 데이터 추출 */
 
-    /* 상태 코드가 1개일 때 해당 일정 확인 */
-    List<Schedule> getSchedulesByStatusCode(Long codeId);
-
-    /* 상태 코드가 2개 이상일 때 해당 일정 확인 */
+    /* 상태 코드에 따른 해당 일정 확인 */
     List<Schedule> getSchedulesByStatusCodes(List<Long> codeIds);
 
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
@@ -191,6 +191,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         return scheduleRepository.findSchedulesByScheduleParentScheduleId(scheduleId) != null;
     }
 
+    /* Title을 통한 일정 검색 */
     @Override
     @Transactional(readOnly = true)
     public List<SearchScheduleListDTO> searchSchedulesByTitle(String scheduleTitle) {
@@ -240,5 +241,17 @@ public class ScheduleServiceImpl implements ScheduleService {
         }
 
         return updates;
+    }
+
+    /* 일정 상태값이 1개일 때 일정 목록 확인 */
+    @Override
+    public List<Schedule> getSchedulesByStatusCode(Long codeId) {
+        return scheduleRepository.findByScheduleStatus(codeId);
+    }
+
+    /* 일정 상태값이 2개 이상일 때 일정 목록 확인 */
+    @Override
+    public List<Schedule> getSchedulesByStatusCodes(List<Long> codeIds) {
+        return scheduleRepository.findByScheduleStatusIn(codeIds);
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
@@ -243,13 +243,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         return updates;
     }
 
-    /* 일정 상태값이 1개일 때 일정 목록 확인 */
-    @Override
-    public List<Schedule> getSchedulesByStatusCode(Long codeId) {
-        return scheduleRepository.findByScheduleStatus(codeId);
-    }
-
-    /* 일정 상태값이 2개 이상일 때 일정 목록 확인 */
+    /* 일정 상태값에 따른 일정 목록 확인 */
     @Override
     public List<Schedule> getSchedulesByStatusCodes(List<Long> codeIds) {
         return scheduleRepository.findByScheduleStatusIn(codeIds);


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #36 

## 📝작업 내용

> 
- 일정의 상태값에 따른 필터 기능 구현
- 준비, 진행, 완료의 공통코드 값을 통해 필터 가능 

### 📷스크린샷 (선택)



## 💬리뷰 요구사항(선택)

> 
- 2개 이상의 상태 값 만으로도 필터 기능의 사용이 가능하긴 하나 추후에 사용할 일이 있을 수도 있을 것 같아 상태 값을 1개만 선택했을 경우와 2개 이상의 상태 값을 선택했을 경우의 메소드를 나누어 구현하였습니다. 구분할 필요가 없다고 판단되면 하나로 줄이는 방향으로 진행하겠습니다. 
