### PR TITLE
[PR] 접근 권한 확인용 AOP 구현

### DIFF
--- a/src/main/java/org/omoknoone/ppm/common/annotation/Permission.java
+++ b/src/main/java/org/omoknoone/ppm/common/annotation/Permission.java
@@ -1,0 +1,11 @@
+package org.omoknoone.ppm.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Permission {
+}

--- a/src/main/java/org/omoknoone/ppm/common/annotation/Permission.java
+++ b/src/main/java/org/omoknoone/ppm/common/annotation/Permission.java
@@ -5,7 +5,26 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * 권한 확인용 어노테이션
+ * <p>
+ * 구성원의 역할을 확인하여 권한별로 메소드의 사용 가능 여부를 확인한다.
+ * </p>
+ * <p>
+ * [속성]
+ * <ul>
+ * <li><b>PM:</b> 프로젝트 매니저가 메서드에 접근할 수 있는지 여부를 나타냅니다. 기본값은 true입니다.</li>
+ * <li><b>PL:</b> 프로젝트 리더가 메서드에 접근할 수 있는지 여부를 나타냅니다. 기본값은 false입니다.</li>
+ * <li><b>PA:</b> 프로젝트 어시스턴트가 메서드에 접근할 수 있는지 여부를 나타냅니다. 기본값은 false입니다.</li>
+ * </ul>
+ * </p>
+ */
+
+
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Permission {
+    boolean PM() default true;
+    boolean PL() default false;
+    boolean PA() default false;
 }

--- a/src/main/java/org/omoknoone/ppm/common/aop/AuthorizationAspect.java
+++ b/src/main/java/org/omoknoone/ppm/common/aop/AuthorizationAspect.java
@@ -14,6 +14,7 @@ import org.omoknoone.ppm.domain.commoncode.service.CommonCodeService;
 import org.omoknoone.ppm.domain.permission.dto.PermissionDTO;
 import org.omoknoone.ppm.domain.permission.service.PermissionService;
 import org.omoknoone.ppm.domain.projectmember.service.ProjectMemberService;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
@@ -25,13 +26,13 @@ import java.util.List;
 @RequiredArgsConstructor
 @Aspect
 @Component
+@Order(1)
 public class AuthorizationAspect {
 
     private final HttpServletRequest request;
     private final ProjectMemberService projectMemberService;
     private final PermissionService permissionService;
     private final CommonCodeService commonCodeService;
-    private final Environment environment;
 
     @Pointcut("@annotation(org.omoknoone.ppm.common.annotation.Permission)")
     private void annotationPointcut() {}

--- a/src/main/java/org/omoknoone/ppm/common/aop/AuthorizationAspect.java
+++ b/src/main/java/org/omoknoone/ppm/common/aop/AuthorizationAspect.java
@@ -1,0 +1,78 @@
+package org.omoknoone.ppm.common.aop;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeResponseDTO;
+import org.omoknoone.ppm.domain.commoncode.service.CommonCodeService;
+import org.omoknoone.ppm.domain.permission.dto.PermissionDTO;
+import org.omoknoone.ppm.domain.permission.service.PermissionService;
+import org.omoknoone.ppm.domain.projectmember.service.ProjectMemberService;
+import org.springframework.core.env.Environment;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Aspect
+@Component
+public class AuthorizationAspect {
+
+    private final HttpServletRequest request;
+    private final ProjectMemberService projectMemberService;
+    private final PermissionService permissionService;
+    private final CommonCodeService commonCodeService;
+    private final Environment environment;
+
+    @Pointcut("@annotation(org.omoknoone.ppm.common.annotation.Permission)")
+    private void annotationPointcut() {}
+
+    @Before("annotationPointcut()")
+    public void checkProjectMemberPermission() throws AccessDeniedException {
+        log.info("[AOP 실행]");
+        // HttpServletRequest 객체를 사용하여 요청 헤더 정보 추출
+        String employeeId = request.getHeader("employeeId");
+        Integer projectId = Integer.parseInt(request.getHeader("projectId"));
+        log.info("employeeId : {}, projectId : {}", employeeId, projectId);
+        // projectId와 employeeId로 구성원Id 조회
+        Integer projectMemberId = projectMemberService.viewProjectMemberId(employeeId, projectId);
+        log.info("projectMemberID : {}", projectMemberId);
+
+        // 구성원Id로 권한 목록 조회 (PL or 개발자는 여러개 일 수 있다)
+        List<PermissionDTO> projectPermissionList = permissionService.viewMemberPermission(Long.valueOf(projectMemberId));
+        for (PermissionDTO permissionDTO : projectPermissionList) {
+            log.info("permissionDTO : {}", permissionDTO);
+        }
+
+        // 권한 역할명(PM, PL, 참여자) 조회
+        List<CommonCodeResponseDTO> permissionNameCommonCodeList = commonCodeService.viewCommonCodesByGroup(106L);
+        for (CommonCodeResponseDTO commonCodeResponseDTO : permissionNameCommonCodeList) {
+            log.info("commonCodeResponseDTO : {}", commonCodeResponseDTO);
+        }
+
+        // 권한Id가 여러개일 경우(여러 일정을 담당하는 개발자 or 여러 섹션을 관리하는 PL)
+        for (PermissionDTO projectPermission : projectPermissionList) {    // 프로젝트 권한 목록
+            for (CommonCodeResponseDTO permissionNameCommonCode : permissionNameCommonCodeList) {    // 권한 역할 목록
+                String codeName = permissionNameCommonCode.getCodeName();
+                Long codeId = permissionNameCommonCode.getCodeId();
+
+                // TODO. 여기 코드 수정 해야 함
+
+                if("PM".equals(codeName) && codeId.equals(projectPermission.getPermissionRoleName())) {
+                    log.info("PM이다!!!");
+                    continue;
+                } else if ("PL".equals(codeName) && codeId.equals(projectPermission.getPermissionProjectMemberId())) {
+                    // 권한이 PL인 경우
+                    log.info("PL이다!!!");
+                } else {
+                    throw new AccessDeniedException(environment.getProperty("exception.controller.accessDenied"));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/omoknoone/ppm/common/aop/AuthorizationAspect.java
+++ b/src/main/java/org/omoknoone/ppm/common/aop/AuthorizationAspect.java
@@ -1,5 +1,7 @@
 package org.omoknoone.ppm.common.aop;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,11 +16,14 @@ import org.omoknoone.ppm.domain.commoncode.service.CommonCodeService;
 import org.omoknoone.ppm.domain.permission.dto.PermissionDTO;
 import org.omoknoone.ppm.domain.permission.service.PermissionService;
 import org.omoknoone.ppm.domain.projectmember.service.ProjectMemberService;
+import org.omoknoone.ppm.domain.schedule.dto.ScheduleDTO;
+import org.omoknoone.ppm.domain.schedule.service.ScheduleService;
 import org.springframework.core.annotation.Order;
-import org.springframework.core.env.Environment;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -33,6 +38,8 @@ public class AuthorizationAspect {
     private final ProjectMemberService projectMemberService;
     private final PermissionService permissionService;
     private final CommonCodeService commonCodeService;
+    private final ScheduleService scheduleService;
+    private final ObjectMapper objectMapper;
 
     @Pointcut("@annotation(org.omoknoone.ppm.common.annotation.Permission)")
     private void annotationPointcut() {}
@@ -48,8 +55,11 @@ public class AuthorizationAspect {
         List<CommonCodeResponseDTO> commonCodeList = commonCodeService
                                                         .viewCommonCodesByGroupName("권한 역할명");
 
-        // 요청자의 권한 코드 알아내기
-        PermissionDTO permissionDTO = getRequesterPermissionCode();
+        // 요청자의 권한 코드 목록 조회
+        List<PermissionDTO> permissionDTOList = getRequesterPermissionCodeList();
+
+        // 요청자의 가장 높은 권한 조회
+        PermissionDTO permissionDTO = getHighestPermissionCode(permissionDTOList);
 
         // 요정차의 권한 이름 가져오기
         String requesterPermission = getRequesterPermission(commonCodeList, permissionDTO);
@@ -57,16 +67,95 @@ public class AuthorizationAspect {
         if (permissionAnnotation.PM() && requesterPermission.equals("PM")) {            // PM 권한
             log.info("요청자의 권한은 {}입니다", requesterPermission);
         } else if (permissionAnnotation.PL() && requesterPermission.equals("PL")) {     // PL 권한
+
+            // PL인 권한만 추출
+            List<PermissionDTO> plPermissionList = getPermissionListByRoleName(
+                                                                commonCodeList, permissionDTOList, requesterPermission);
+
+            // 요청 일정 ID를 Body에서 가져오기
+            String scheduleId = extractScheduleIdFromRequestBody();
+
+            // 일정 담당 여부를 확인
+            boolean isPlResponsibleForSchedule = checkResponsibleForSchedule(plPermissionList, scheduleId, true);
+
+            if (!isPlResponsibleForSchedule) {
+                throw new AccessDeniedException("Access Denied: 요청자가 해당 일정을 담당하지 않습니다.");
+            }
+
             log.info("요청자의 권한은 {}입니다", requesterPermission);
         } else if (permissionAnnotation.PA() && requesterPermission.equals("PA")) {     // PA 권한
+            // PA인 권한만 추출
+            List<PermissionDTO> paPermissionList = getPermissionListByRoleName(
+                                                                commonCodeList, permissionDTOList, requesterPermission);
+
+            // 요청 일정 ID를 Body에서 가져오기
+            String scheduleId = extractScheduleIdFromRequestBody();
+
+            // 일정 담당 여부를 확인
+            boolean isPlResponsibleForSchedule = checkResponsibleForSchedule(paPermissionList, scheduleId, false);
+
+            if (!isPlResponsibleForSchedule) {
+                throw new AccessDeniedException("Access Denied: 요청자가 해당 일정을 담당하지 않습니다.");
+            }
+
             log.info("요청자의 권한은 {}입니다", requesterPermission);
         } else {                                                                        // 권한 없음
-            throw new AccessDeniedException("Access Denied\n요청자의 권한 : " + requesterPermission);
+            throw new AccessDeniedException("Access Denied: 요청자의 권한 [" + requesterPermission + "]");
+        }
+    }
+
+    private boolean checkResponsibleForSchedule(List<PermissionDTO> permissionDTOList, String scheduleId, boolean isPL) {
+        Long requestScheduleId = Long.parseLong(scheduleId);
+
+        for (PermissionDTO permissionDTO : permissionDTOList) {
+            if (permissionDTO.getPermissionScheduleId().equals(requestScheduleId)) {
+                return true;
+            } else if (isPL) { // PL 권한인 경우에만 하위 일정 확인
+                List<ScheduleDTO> subScheduleList = scheduleService
+                                                            .viewSubSchedules(permissionDTO.getPermissionScheduleId());
+                for (ScheduleDTO subSchedule : subScheduleList) {
+                    if (subSchedule.getScheduleId().equals(requestScheduleId))
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private List<PermissionDTO> getPermissionListByRoleName(
+            List<CommonCodeResponseDTO> commonCodeList, List<PermissionDTO> permissionDTOList, String roleName) {
+
+        List<PermissionDTO> permissionList = new ArrayList<>();
+
+        for (CommonCodeResponseDTO commonCode : commonCodeList) {
+            if (commonCode.getCodeName().equals(roleName)) {
+                for (PermissionDTO permissionDTO : permissionDTOList) {
+                    if (permissionDTO.getPermissionRoleName().equals(commonCode.getCodeId())) {
+                        permissionList.add(permissionDTO);
+                    }
+                }
+            }
+        }
+        return permissionList;
+    }
+
+    // 일정 ID를 Body에서 가져오기
+    private String extractScheduleIdFromRequestBody() {
+        try {
+            // 요청 본문을 JSON 형식으로 파싱
+            JsonNode requestBody = objectMapper.readTree(request.getInputStream());
+            // scheduleId 추출
+            if (!requestBody.has("scheduleId")) {
+                throw new IllegalArgumentException("Request body에 'scheduleId' 필드값이 없습니다");
+            }
+            return requestBody.get("scheduleId").asText();
+        } catch (IOException e) {
+            throw new RuntimeException("요청 본문을 읽는 중 오류 발생", e);
         }
     }
 
     // 요청자의 권한 코드 알아내기
-    private PermissionDTO getRequesterPermissionCode() {
+    private List<PermissionDTO> getRequesterPermissionCodeList() {
         String employeeId = request.getHeader("employeeId");
         Integer projectId = Integer.parseInt(request.getHeader("projectId"));
 
@@ -74,17 +163,17 @@ public class AuthorizationAspect {
         Integer projectMemberId = projectMemberService.viewProjectMemberId(employeeId, projectId);
 
         // 구성원Id로 권한 목록 조회 (PL or 개발자는 여러개 일 수 있다)
-        List<PermissionDTO> projectPermissionList = permissionService
-                                                            .viewMemberPermission(Long.valueOf(projectMemberId));
+        return permissionService.viewMemberPermission(Long.valueOf(projectMemberId));
+    }
 
-        // 가장 높은 권한을 가진 Permission 반환
+    private PermissionDTO getHighestPermissionCode(List<PermissionDTO> projectPermissionList) {
         return projectPermissionList.stream()
                 .min(Comparator.comparing(PermissionDTO::getPermissionRoleName))
                 .orElse(null);
     }
 
     // 요정차의 권한 이름 가져오기
-    private static String getRequesterPermission(List<CommonCodeResponseDTO> commonCodeList, PermissionDTO permissionDTO) {
+    private String getRequesterPermission(List<CommonCodeResponseDTO> commonCodeList, PermissionDTO permissionDTO) {
         String requesterPermission = null;
         for (CommonCodeResponseDTO commonCode : commonCodeList) {
             if (permissionDTO.getPermissionRoleName().equals(commonCode.getCodeId())){

--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/repository/CommonCodeGroupRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/repository/CommonCodeGroupRepository.java
@@ -4,4 +4,5 @@ import org.omoknoone.ppm.domain.commoncode.aggregate.CommonCodeGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommonCodeGroupRepository extends JpaRepository<CommonCodeGroup, Long> {
+    CommonCodeGroup findByCodeGroupName(String codeGroupName);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/repository/CommonCodeRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/repository/CommonCodeRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 public interface CommonCodeRepository extends JpaRepository<CommonCode, Long> {
 
     // 외래 키를 기준으로 CommonCode 검색
-    List<CommonCodeResponseDTO> findByCodeGroupId(Long codeGroupId);
+    List<CommonCode> findByCodeGroupId(Long codeGroupId);
 
 }

--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeService.java
@@ -14,4 +14,6 @@ public interface CommonCodeService {
      List<CommonCodeGroupResponseDTO> viewAllCommonCodeGroups();
 
      CommonCodeGroupResponseDTO viewCommonCodeGroupById(Long groupId);
+
+     List<CommonCodeResponseDTO> viewCommonCodesByGroupName(String codeGroupName);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeServiceImpl.java
@@ -2,6 +2,7 @@ package org.omoknoone.ppm.domain.commoncode.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import org.omoknoone.ppm.domain.commoncode.aggregate.CommonCode;
+import org.omoknoone.ppm.domain.commoncode.aggregate.CommonCodeGroup;
 import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeResponseDTO;
 import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeGroupResponseDTO;
 import org.omoknoone.ppm.domain.commoncode.repository.CommonCodeGroupRepository;
@@ -92,4 +93,21 @@ public class CommonCodeServiceImpl implements CommonCodeService {
                             group.getCodeGroupDescription()))
                     .orElseThrow(() -> new EntityNotFoundException("exception.data.entityNotFound"));
         }
+
+    @Override
+    public List<CommonCodeResponseDTO> viewCommonCodesByGroupName(String codeGroupName) {
+        CommonCodeGroup codeGroup = commonCodeGroupRepository.findByCodeGroupName(codeGroupName);
+
+        List<CommonCode> codeList = commonCodeRepository.findByCodeGroupId(codeGroup.getCodeGroupId());
+
+        if (codeList.isEmpty()) {
+            throw new EntityNotFoundException("exception.data.entityNotFound");
+        }
+
+        return codeList.stream()
+                .map(code -> new CommonCodeResponseDTO(code.getCodeId(),
+                        code.getCodeName(),
+                        code.getCodeDescription()))
+                .collect(Collectors.toList());
     }
+}

--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeServiceImpl.java
@@ -35,7 +35,6 @@ public class CommonCodeServiceImpl implements CommonCodeService {
             throw new IllegalArgumentException("exception.service.illegalArgument");
         }
         try {
-            System.out.println("[viewCommonCodesByGroup] groupId = " + groupId);
             List<CommonCode> codes = commonCodeRepository.findByCodeGroupId(groupId);
             if (codes.isEmpty()) {
                 throw new EntityNotFoundException("exception.data.entityNotFound");

--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeServiceImpl.java
@@ -1,6 +1,7 @@
 package org.omoknoone.ppm.domain.commoncode.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.omoknoone.ppm.domain.commoncode.aggregate.CommonCode;
 import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeResponseDTO;
 import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeGroupResponseDTO;
 import org.omoknoone.ppm.domain.commoncode.repository.CommonCodeGroupRepository;
@@ -33,7 +34,8 @@ public class CommonCodeServiceImpl implements CommonCodeService {
             throw new IllegalArgumentException("exception.service.illegalArgument");
         }
         try {
-            List<CommonCodeResponseDTO> codes = commonCodeRepository.findByCodeGroupId(groupId);
+            System.out.println("[viewCommonCodesByGroup] groupId = " + groupId);
+            List<CommonCode> codes = commonCodeRepository.findByCodeGroupId(groupId);
             if (codes.isEmpty()) {
                 throw new EntityNotFoundException("exception.data.entityNotFound");
             }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -21,7 +20,7 @@ public class ProjectMember {
 
     @CreatedDate
     @Column(name = "project_member_created_date", nullable = false, length = 30)
-    private LocalDateTime projectMemberCreatedDate;
+    private String projectMemberCreatedDate;
 
     @Column(name = "project_member_modified_date", length = 30)
     private LocalDateTime projectMemberModifiedDate;
@@ -35,20 +34,16 @@ public class ProjectMember {
     @JoinColumn(name = "project_member_project_id", nullable = false)
     private Integer projectMemberProjectId;
 
-    @JoinColumn(name = "project_member_role_id", nullable = false)
-    private Integer projectMemberRoleId;
-
     @JoinColumn(name = "project_member_employee_id", nullable = false)
     private String projectMemberEmployeeId;
 
     @Builder
-    public ProjectMember(Integer projectMemberId, Integer projectMemberProjectId, Integer projectMemberRoleId,
+    public ProjectMember(Integer projectMemberId, Integer projectMemberProjectId,
                          String projectMemberEmployeeId, Boolean projectMemberIsExcluded,
-                         LocalDateTime projectMemberExclusionDate, LocalDateTime projectMemberCreatedDate,
+                         LocalDateTime projectMemberExclusionDate, String projectMemberCreatedDate,
                          LocalDateTime projectMemberModifiedDate) {
         this.projectMemberId = projectMemberId;
         this.projectMemberProjectId = projectMemberProjectId;
-        this.projectMemberRoleId = projectMemberRoleId;
         this.projectMemberEmployeeId = projectMemberEmployeeId;
         this.projectMemberIsExcluded
                 = projectMemberIsExcluded != null ? projectMemberIsExcluded : false; // null일 경우 기본값 false
@@ -58,7 +53,7 @@ public class ProjectMember {
     }
 
     public void modify(ModifyProjectMemberRequestDTO dto) {
-        this.projectMemberRoleId = dto.getProjectMemberRoleId();
+//        this.projectMemberRoleId = dto.getProjectMemberRoleId();
         this.projectMemberModifiedDate = LocalDateTime.now();
     }
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.omoknoone.ppm.common.ResponseMessage;
+import org.omoknoone.ppm.common.annotation.Permission;
 import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.viewProjectMembersByProjectResponseDTO;
@@ -44,8 +45,10 @@ public class ProjectMemberController {
                 .body(new ResponseMessage(200, "프로젝트 구성원 조회 성공", responseMap));
     }
 
+    @Permission
     @PostMapping("/create")
     public ResponseEntity<ResponseMessage> createProjectMember(@RequestBody CreateProjectMemberRequestDTO requestDTO) {
+        log.info("[Controller] requestDTO : {}", requestDTO);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
@@ -45,10 +45,8 @@ public class ProjectMemberController {
                 .body(new ResponseMessage(200, "프로젝트 구성원 조회 성공", responseMap));
     }
 
-    @Permission
     @PostMapping("/create")
     public ResponseEntity<ResponseMessage> createProjectMember(@RequestBody CreateProjectMemberRequestDTO requestDTO) {
-        log.info("[Controller] requestDTO : {}", requestDTO);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberRepository.java
@@ -12,5 +12,5 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, In
     @Query("SELECT pm FROM ProjectMember pm WHERE pm.projectMemberProjectId = :projectId")
     List<ProjectMember> findByProjectMemberProjectId(@Param("projectId") Integer projectId);
 
-
+    ProjectMember findByProjectMemberEmployeeIdAndProjectMemberProjectId(String employeeId, Integer projectId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
@@ -17,4 +17,5 @@ public interface ProjectMemberService {
 
     Integer modifyProjectMember(ModifyProjectMemberRequestDTO modifyProjectMemberRequestDTO);
 
+    Integer viewProjectMemberId(String employeeId, Integer projectId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
@@ -81,12 +81,8 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
 
     @Override
     public Integer viewProjectMemberId(String employeeId, Integer projectId) {
-        System.out.println("viewProjectMemberId()");
-        System.out.println("employeeId = " + employeeId);
-        System.out.println("projectId = " + projectId);
         ProjectMember projectMember = projectMemberRepository.
                 findByProjectMemberEmployeeIdAndProjectMemberProjectId(employeeId, projectId);
-        System.out.println("projectMember = " + projectMember);
         return projectMember.getProjectMemberId();
     }
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
@@ -42,7 +42,7 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
     public Integer createProjectMember(CreateProjectMemberRequestDTO dto) {
         ProjectMember newMember = modelMapper.map(dto, ProjectMember.class);
 
-        projectMemberRepository.save(newMember);
+//        projectMemberRepository.save(newMember);
 
         return newMember.getProjectMemberId();
     }
@@ -77,6 +77,17 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
         projectMemberRepository.save(existingMember);
 
         return existingMember.getProjectMemberId();
+    }
+
+    @Override
+    public Integer viewProjectMemberId(String employeeId, Integer projectId) {
+        System.out.println("viewProjectMemberId()");
+        System.out.println("employeeId = " + employeeId);
+        System.out.println("projectId = " + projectId);
+        ProjectMember projectMember = projectMemberRepository.
+                findByProjectMemberEmployeeIdAndProjectMemberProjectId(employeeId, projectId);
+        System.out.println("projectMember = " + projectMember);
+        return projectMember.getProjectMemberId();
     }
 
 }

--- a/src/main/java/org/omoknoone/ppm/domain/requirements/controller/RequirementsController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/requirements/controller/RequirementsController.java
@@ -14,13 +14,7 @@ import org.omoknoone.ppm.domain.requirements.vo.ResponseRequirementsListByProjec
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
@@ -88,4 +88,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         + "    pm.projectMemberId ")
     List<UpdateTableDataDTO> UpdateTableData(Long projectId);
 
+    List<Schedule> findByScheduleParentScheduleId(Long scheduleId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
@@ -59,4 +59,7 @@ public interface ScheduleService {
     /* 설명. 대시보드 컬럼 제공 데이터 추출 */
 
     /* 설명. 대시보드 라인 제공 데이터 추출 */
+
+    // 현재 일정의 모든 하위 일정 조회
+    List<ScheduleDTO> viewSubSchedules(Long scheduleId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
@@ -1,8 +1,6 @@
 package org.omoknoone.ppm.domain.schedule.service;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
@@ -240,5 +238,24 @@ public class ScheduleServiceImpl implements ScheduleService {
         }
 
         return updates;
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ScheduleDTO> viewSubSchedules(Long scheduleId) {
+        List<ScheduleDTO> subSchedules = new ArrayList<>();
+        Stack<Long> stack = new Stack<>();
+        stack.push(scheduleId);
+
+        while (!stack.isEmpty()) {
+            Long currentId = stack.pop();
+            List<Schedule> childSchedules = scheduleRepository.findByScheduleParentScheduleId(currentId);
+            for (Schedule childSchedule : childSchedules) {
+                subSchedules.add(modelMapper.map(childSchedule, ScheduleDTO.class));
+                stack.push(childSchedule.getScheduleId());
+            }
+        }
+
+        return subSchedules;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #102 

## 📝작업 내용

### 개요
- 프로젝트 멤버의 권한에 따라 특정 메소드의 접근을 제어하는 AOP 로직을 구현하였습니다.
- `@Permission` 어노테이션을 메소드에 적용하여 PM, PL, PA 각 권한별로 메소드 접근 여부를 설정할 수 있습니다.

### 주요 기능
- 권한 확인을 위해 `CommonCodeService`를 통해 '권한 역할명' 공통 코드를 조회합니다.
- 요청자의 권한 코드 목록을 `PermissionService`를 통해 조회합니다.
- 요청자의 가장 높은 권한을 확인하여 PM, PL, PA 중 어디에 해당하는지 판단합니다.
- PM 권한인 경우에는 무조건 메소드 접근을 허용합니다.
- PL, PA 권한인 경우에는 요청한 일정 ID가 자신이 담당하는 일정인지 확인합니다.
  - PL은 하위 일정까지 확인하며, PA는 자신이 직접 담당하는 일정만 확인합니다.
  - 담당 일정이 아닌 경우에는 `AccessDeniedException`을 발생시켜 접근을 거부합니다.

## 💬리뷰 요구사항(선택)

> 제가 생각하지 못한 권한 확인 절차에 대해서 확인부탁드립니다.
> PA의 일정에 업무가 있으면 업무 수정 가능, 업무가 없으면 일정 수정 가능 에 대한 기능은 추후에 개발할 예정입니다.
