### PR TITLE
[PR]  해당 일자가 포함된 주에 끝나야할 일정 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/omoknoone/ppm/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/controller/ProjectController.java
@@ -7,6 +7,7 @@ import org.omoknoone.ppm.domain.project.dto.CreateProjectRequestDTO;
 import org.omoknoone.ppm.domain.project.dto.ModifyProjectHistoryDTO;
 import org.omoknoone.ppm.domain.project.dto.ModifyProjectRequestDTO;
 import org.omoknoone.ppm.domain.project.service.ProjectService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -14,7 +15,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.Charset;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -54,5 +58,15 @@ public class ProjectController {
                 .ok()
                 .headers(headers)
                 .body(new ResponseMessage(200, "프로젝트 수정 성공", responseMap));
+    }
+
+    /* 프로젝트 일정 10등분 */
+    @GetMapping("/workingDaysDivideTen")
+    public ResponseEntity<List<LocalDate>> divideWorkingDays(
+        @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+        @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
+    ) {
+        List<LocalDate> dividedDates = projectService.divideWorkingDaysIntoTen(startDate, endDate);
+        return ResponseEntity.ok(dividedDates);
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/project/service/ProjectService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/service/ProjectService.java
@@ -1,5 +1,9 @@
 package org.omoknoone.ppm.domain.project.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.omoknoone.ppm.domain.project.dto.CreateProjectRequestDTO;
 import org.omoknoone.ppm.domain.project.dto.ModifyProjectHistoryDTO;
 import org.omoknoone.ppm.domain.project.dto.ModifyProjectRequestDTO;
@@ -8,4 +12,6 @@ public interface ProjectService {
     int createProject(CreateProjectRequestDTO createProjectRequestDTO);
 
     int modifyProject(ModifyProjectHistoryDTO modifyProjectRequestDTO);
+
+	List<LocalDate> divideWorkingDaysIntoTen(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/service/ProjectServiceImpl.java
@@ -1,10 +1,16 @@
 package org.omoknoone.ppm.domain.project.service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.omoknoone.ppm.domain.holiday.aggregate.Holiday;
+import org.omoknoone.ppm.domain.holiday.repository.HolidayRepository;
 import org.omoknoone.ppm.domain.project.aggregate.Project;
 import org.omoknoone.ppm.domain.project.aggregate.ProjectHistory;
 import org.omoknoone.ppm.domain.project.dto.CreateProjectRequestDTO;
@@ -21,6 +27,7 @@ public class ProjectServiceImpl implements ProjectService {
 
     private final ProjectHistoryService projectHistoryService;
     private final ProjectRepository projectRepository;
+    private final HolidayRepository holidayRepository;
     private final ModelMapper modelMapper;
 
     @Transactional
@@ -43,5 +50,89 @@ public class ProjectServiceImpl implements ProjectService {
         projectHistoryService.createProjectHistory(modifyProjectHistoryDTO);
 
         return projectRepository.findById(modifyProjectHistoryDTO.getProjectId()).get().getId();
+    }
+
+    @Override
+    public List<LocalDate> divideWorkingDaysIntoTen(LocalDateTime projectStartDate, LocalDateTime projectEndDate) {
+        // WorkingDays 총 일수를 가져옴
+        int totalWorkingDays = calculateWorkingDays(projectStartDate.toLocalDate(), projectEndDate.toLocalDate());
+
+        // WorkingDays가 0일 경우 빈 문자열 반환
+        if (totalWorkingDays == 0) {
+            return new ArrayList<>();
+        }
+
+        // WorkingDays의 Date -> List
+        List<LocalDate> workingDays = getWorkingDaysList(projectStartDate.toLocalDate(), projectEndDate.toLocalDate());
+
+        // WorkingDays를 10등분
+        List<LocalDate> dividedDates = new ArrayList<>();
+        int divideDays = totalWorkingDays / 10;
+        int remainDays = totalWorkingDays % 10;
+
+        for (int i = 0; i < 10; i++) {
+            int days = i * divideDays + Math.min(i, remainDays);
+            if (days < workingDays.size()) {
+                dividedDates.add(workingDays.get(days));
+            }
+        }
+
+        return dividedDates;
+    }
+
+    private List<LocalDate> getWorkingDaysList(LocalDate startDate, LocalDate endDate) {
+        List<LocalDate> workingDays = new ArrayList<>();
+        List<Holiday> holidays = holidayRepository.findHolidaysBetween(
+            startDate.getYear(), startDate.getMonthValue(), startDate.getDayOfMonth(),
+            endDate.getYear(), endDate.getMonthValue(), endDate.getDayOfMonth()
+        );
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            final int currentYear = date.getYear();
+            final int currentMonth = date.getMonthValue();
+            final int currentDay = date.getDayOfMonth();
+
+            DayOfWeek dayOfWeek = date.getDayOfWeek();
+            boolean isWeekend = (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY);
+            boolean isHoliday = holidays.stream()
+                .anyMatch(holiday -> holiday.getHolidayYear() == currentYear
+                    && holiday.getHolidayMonth() == currentMonth
+                    && holiday.getHolidayDay() == currentDay);
+
+            if (!isWeekend && !isHoliday) {
+                workingDays.add(date);
+            }
+        }
+
+        return workingDays;
+    }
+
+    private int calculateWorkingDays(LocalDate startDate, LocalDate endDate) {
+        int workingDays = 0;
+
+        // 기간 내의 모든 공휴일을 조회합니다.
+        List<Holiday> holidays = holidayRepository.findHolidaysBetween(
+            startDate.getYear(), startDate.getMonthValue(), startDate.getDayOfMonth(),
+            endDate.getYear(), endDate.getMonthValue(), endDate.getDayOfMonth()
+        );
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            final int currentYear = date.getYear();
+            final int currentMonth = date.getMonthValue();
+            final int currentDay = date.getDayOfMonth();
+
+            DayOfWeek dayOfWeek = date.getDayOfWeek();
+            boolean isWeekend = (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY);
+            boolean isHoliday = holidays.stream()
+                .anyMatch(holiday -> holiday.getHolidayYear() == currentYear
+                    && holiday.getHolidayMonth() == currentMonth
+                    && holiday.getHolidayDay() == currentDay);
+
+            if (!isWeekend && !isHoliday) {
+                workingDays++;
+            }
+        }
+
+        return workingDays;
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
@@ -181,4 +181,11 @@ public class ScheduleController {
 
         return ResponseEntity.status(HttpStatus.OK).body(responseScheduleList);
     }
+
+    /* 해당 일자가 포함된 주에 끝나야할 일정 목록 조회 */
+    @GetMapping("/thisweek")
+    public ResponseEntity<List<Schedule>> findSchedulesForThisWeek(){
+        List<Schedule> schedules = scheduleService.getSchedulesForThisWeek();
+        return ResponseEntity.ok(schedules);
+    }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
@@ -100,4 +100,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         + "AND s.scheduleEndDate >= :startDate AND s.scheduleIsDeleted = false")
     List<Schedule> findSchedulesByDateRange(@Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate);
+
+    /* 해당 일자가 포함된 주에 끝나야할 일정 목록 조회 */
+    @Query("SELECT s FROM Schedule s WHERE s.scheduleEndDate >= :thisMonday AND s.scheduleEndDate <= :thisSunday")
+    List<Schedule> getSchedulesForThisWeek(@Param("thisMonday") LocalDate thisMonday, @Param("thisSunday") LocalDate thisSunday);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
@@ -70,4 +70,7 @@ public interface ScheduleService {
 
     /* 날짜 설정 범위에 따른 일정 확인 */
     List<ScheduleDTO> viewSchedulesByDateRange(LocalDate startDate, LocalDate endDate);
+
+    /* 해당 일자가 포함된 주에 끝나야할 일정 목록 조회 */
+	List<Schedule> getSchedulesForThisWeek();
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
@@ -1,8 +1,13 @@
 package org.omoknoone.ppm.domain.schedule.service;
 
-import java.util.*;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
 
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
@@ -314,4 +319,13 @@ public class ScheduleServiceImpl implements ScheduleService {
 
         return subSchedules;
     }
+
+	/* 해당 일자가 포함된 주에 끝나야할 일정 목록 조회 */
+	@Override
+	public List<Schedule> getSchedulesForThisWeek() {
+		LocalDate today = LocalDate.now();
+		LocalDate thisMonday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+		LocalDate thisSunday = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+		return scheduleRepository.getSchedulesForThisWeek(thisMonday, thisSunday);
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #37 

## 📝작업 내용

> 
- 사용자가 필터 설정 시의 DateTime 일자가 포함된 주에 끝나야 할 일정 목록을 조회하는 기능 
- PM이 입력한 프로젝트의 startDate와 endDate 사이의 일 수를 10개 구간으로 동일하게 나누는 기능 추가

### 📷스크린샷 (선택)
![이번주 일정](https://github.com/OmokNoonE/PPM-backend/assets/38232456/f91c8ef3-fa08-430d-b355-c953e8155b70)
![10개구간나누기](https://github.com/OmokNoonE/PPM-backend/assets/38232456/f4e2dcdb-c91e-4f78-971d-68954acbd070)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
```
// 참고
LocalDateTime currentDateTime = LocalDateTime.now();
LocalDateTime targetDateTime = currentDateTime
        .with(TemporalAdjusters.firstDayOfYear())       // 이번 년도의 첫 번째 일(1월 1일)
        .with(TemporalAdjusters.lastDayOfYear())        // 이번 년도의 마지막 일(12월 31일)
        .with(TemporalAdjusters.firstDayOfNextYear())   // 다음 년도의 첫 번째 일(1월 1일)
        .with(TemporalAdjusters.firstDayOfMonth())      // 이번 달의 첫 번째 일(1일)
        .with(TemporalAdjusters.lastDayOfMonth())       // 이번 달의 마지막 일
        .with(TemporalAdjusters.firstDayOfNextMonth())  // 다음 달의 첫 번째 일(1일)
        .with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY)) // 이번 달의 첫 번째 요일(여기서는 월요일)
        .with(TemporalAdjusters.lastInMonth(DayOfWeek.FRIDAY))  // 이번 달의 마지막 요일(여기서는 마지막 금요일)
        .with(TemporalAdjusters.next(DayOfWeek.FRIDAY))       // 다음주 금요일
        .with(TemporalAdjusters.nextOrSame(DayOfWeek.FRIDAY)) // 다음 금요일(오늘 포함. 오늘이 금요일이라면 오늘 날짜가 표시 된다.)
        .with(TemporalAdjusters.previous(DayOfWeek.FRIDAY))     // 지난주 금요일
        .with(TemporalAdjusters.previousOrSame(DayOfWeek.FRIDAY));// 지난 금요일(오늘 포함)
```