### PR TITLE
[PR] 컨트롤러 반환 형태 ResponseMessage 클래스 사용으로 변경

### DIFF
--- a/src/main/java/org/omoknoone/ppm/common/HttpHeadersCreator.java
+++ b/src/main/java/org/omoknoone/ppm/common/HttpHeadersCreator.java
@@ -1,0 +1,15 @@
+package org.omoknoone.ppm.common;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.nio.charset.StandardCharsets;
+
+public class HttpHeadersCreator {
+
+    public static HttpHeaders createHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return headers;
+    }
+}

--- a/src/main/java/org/omoknoone/ppm/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/employee/controller/EmployeeController.java
@@ -2,6 +2,7 @@ package org.omoknoone.ppm.domain.employee.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.employee.aggregate.Employee;
 import org.omoknoone.ppm.domain.employee.dto.ModifyEmployeeRequestDTO;
@@ -29,13 +30,12 @@ public class EmployeeController {
     @GetMapping("/view/{employeeId}")
     public ResponseEntity<ResponseMessage> viewEmployee(@PathVariable("employeeId") String employeeId) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         ViewEmployeeResponseDTO responseEmployeeDTO = employeeService.viewEmployee(employeeId);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", responseEmployeeDTO);
+        responseMap.put("viewEmployee", responseEmployeeDTO);
 
         return ResponseEntity
                 .ok()
@@ -46,13 +46,12 @@ public class EmployeeController {
     @PutMapping("/modify")
     public ResponseEntity<ResponseMessage> modifyEmployee(@RequestBody ModifyEmployeeRequestDTO modifyEmployeeRequestDTO) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         String employeeId = employeeService.modifyEmployee(modifyEmployeeRequestDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", employeeId);
+        responseMap.put("modifyEmployee", employeeId);
 
         return ResponseEntity
                 .ok()
@@ -63,42 +62,48 @@ public class EmployeeController {
     @PostMapping("/signup")
     public ResponseEntity<ResponseMessage> signUp(@RequestBody SignUpEmployeeRequestDTO signUpEmployeeRequestDTO) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         String employeeId = employeeService.signUp(signUpEmployeeRequestDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", employeeId);
+        responseMap.put("signUp", employeeId);
 
         return ResponseEntity
                 .ok()
                 .headers(headers)
                 .body(new ResponseMessage(200, "회원 가입 성공", responseMap));
     }
-  
+
     /* employeeName을 통한 사원검색 */
     @GetMapping("/search/{employeeName}")
-    public ResponseEntity<ViewEmployeeResponseDTO> searchEmployeeByName(@PathVariable String employeeName) {
+    public ResponseEntity<ResponseMessage> searchEmployeeByName(@PathVariable String employeeName) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         ViewEmployeeResponseDTO viewEmployeeResponseDTO = employeeService.searchEmployeeByName(employeeName);
 
-        return ResponseEntity.ok(viewEmployeeResponseDTO);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("searchEmployeeByName", viewEmployeeResponseDTO);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "회원 검색 성공", responseMap));
     }
     
     @PutMapping("/password/{employeeId}")
     public ResponseEntity<ResponseMessage> modifyPassword(
                     @PathVariable String employeeId, @RequestBody ModifyPasswordRequestDTO modifyPasswordRequestDTO) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         modifyPasswordRequestDTO.setEmployeeId(employeeId);
 
         String modifiedEmployeeId = employeeService.modifyPassword(modifyPasswordRequestDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("employeeId", modifiedEmployeeId);
+        responseMap.put("modifyPassword", modifiedEmployeeId);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/org/omoknoone/ppm/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/notification/controller/NotificationController.java
@@ -2,13 +2,18 @@ package org.omoknoone.ppm.domain.notification.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
+import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.notification.dto.NotificationRequestDTO;
 import org.omoknoone.ppm.domain.notification.dto.NotificationResponseDTO;
 import org.omoknoone.ppm.domain.notification.service.NotificationService;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -20,22 +25,52 @@ public class NotificationController {
 
     /* 필기. 수동으로 알림을 생성 하는 경우 */
     @PostMapping("create")
-    public ResponseEntity<NotificationResponseDTO> createNotification(@RequestBody NotificationRequestDTO requestDTO) {
+    public ResponseEntity<ResponseMessage> createNotification(@RequestBody NotificationRequestDTO requestDTO) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
         NotificationResponseDTO responseDTO = notificationService.createNotification(requestDTO);
-        return ResponseEntity.ok(responseDTO);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("createNotification", responseDTO);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "알림 생성 성공", responseMap));
     }
 
     /* 설명. 최근 날짜 기준 10건의 알림 목록을 화면에 보여줍니다. */
     @GetMapping("/recent/{employeeId}")
-    public ResponseEntity<List<NotificationResponseDTO>> getRecentNotifications(@PathVariable String employeeId) {
+    public ResponseEntity<ResponseMessage> getRecentNotifications(@PathVariable String employeeId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
         List<NotificationResponseDTO> responseDTOList = notificationService.viewRecentNotifications(employeeId);
-        return ResponseEntity.ok(responseDTOList);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("getRecentNotifications", responseDTOList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "최근 알림 조회 성공", responseMap));
     }
 
     /* 설명. 해당 알림을 읽음 표시 */
     @PutMapping("/read/{notificationId}")
-    public ResponseEntity<NotificationResponseDTO> markAsRead(@PathVariable Long notificationId) {
+    public ResponseEntity<ResponseMessage> markAsRead(@PathVariable Long notificationId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
         NotificationResponseDTO responseDTO = notificationService.markAsRead(notificationId);
-        return ResponseEntity.ok(responseDTO);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("markAsRead", responseDTO);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "알림 읽음 전환 성공", responseMap));
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/notification/controller/NotificationSettingController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/notification/controller/NotificationSettingController.java
@@ -2,11 +2,17 @@ package org.omoknoone.ppm.domain.notification.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
+import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.notification.dto.NotificationSettingRequestDTO;
 import org.omoknoone.ppm.domain.notification.dto.NotificationSettingResponseDTO;
 import org.omoknoone.ppm.domain.notification.service.NotificationSettingService;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -18,16 +24,36 @@ public class NotificationSettingController {
 
     /* 설명. 알림 옵션을 보여줍니다. */
     @GetMapping("/{employeeId}")
-    public ResponseEntity<NotificationSettingResponseDTO> viewNotificationSetting(@PathVariable String employeeId) {
+    public ResponseEntity<ResponseMessage> viewNotificationSetting(@PathVariable String employeeId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
         NotificationSettingResponseDTO responseDTO = notificationSettingService.viewNotificationSetting(employeeId);
-        return ResponseEntity.ok(responseDTO);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewNotificationSetting", responseDTO);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "알림 옵션 조회 성공", responseMap));
     }
 
     /* 설명. 알림 온오프 기능을 제공합니다. */
     @PutMapping
-    public ResponseEntity<NotificationSettingResponseDTO> updateNotificationSettings
+    public ResponseEntity<ResponseMessage> updateNotificationSettings
             (@RequestBody NotificationSettingRequestDTO requestDTO) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
         NotificationSettingResponseDTO responseDTO = notificationSettingService.updateNotificationSettings(requestDTO);
-        return ResponseEntity.ok(responseDTO);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("updateNotificationSettings", responseDTO);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "알림 옵션 변경 성공", responseMap));
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/permission/controller/PermissionController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/permission/controller/PermissionController.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.permission.aggregate.Permission;
 import org.omoknoone.ppm.domain.permission.dto.CreatePermissionDTO;
@@ -43,8 +44,10 @@ public class PermissionController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<ResponsePermission> createPermission(
+    public ResponseEntity<ResponseMessage> createPermission(
         @RequestBody RequestCreatePermissionDTO requestCreatePermissionDTO) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         CreatePermissionDTO createPermissionDTO = modelMapper.map(requestCreatePermissionDTO,
@@ -54,42 +57,64 @@ public class PermissionController {
 
         ResponsePermission responsePermission = modelMapper.map(permission, ResponsePermission.class);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(responsePermission);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("createPermission", responsePermission);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(201, "권한 생성 성공", responseMap));
     }
 
     @GetMapping("/member/{projectMemberId}")
-    public ResponseEntity<List<ResponsePermission>> viewMemberPermission(
+    public ResponseEntity<ResponseMessage> viewMemberPermission(
         @PathVariable("projectMemberId") Long projectMemberId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<PermissionDTO> permissionDTOList = permissionService.viewMemberPermission(projectMemberId);
         List<ResponsePermission> responsePermissionList = modelMapper.map(permissionDTOList,
             new TypeToken<List<Permission>>() {
             }.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responsePermissionList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewMemberPermission", responsePermissionList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "권한 조회 성공", responseMap));
     }
 
     @GetMapping("/schedule/{scheduleId}")
-    public ResponseEntity<List<ResponsePermission>> viewSchedulePermission(
+    public ResponseEntity<ResponseMessage> viewSchedulePermission(
         @PathVariable("scheduleId") Long scheduleId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
         List<PermissionDTO> permissionDTOList = permissionService.viewSchedulePermission(scheduleId);
         List<ResponsePermission> responsePermissionList = modelMapper.map(permissionDTOList,
             new TypeToken<List<Permission>>() {
             }.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responsePermissionList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewSchedulePermission", responsePermissionList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 권한 조회 성공", responseMap));
     }
 
     @DeleteMapping("/remove/{permissionId}")
     public ResponseEntity<ResponseMessage> removePermission(@PathVariable("permissionId") Long permissionId) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         Long removedPermissionId = permissionService.removePermission(permissionId);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", removedPermissionId);
+        responseMap.put("removePermission", removedPermissionId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .headers(headers)

--- a/src/main/java/org/omoknoone/ppm/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/controller/ProjectController.java
@@ -2,6 +2,7 @@ package org.omoknoone.ppm.domain.project.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.project.dto.CreateProjectRequestDTO;
 import org.omoknoone.ppm.domain.project.dto.ModifyProjectHistoryDTO;
@@ -31,12 +32,12 @@ public class ProjectController {
 
     @PostMapping("/create")
     public ResponseEntity<ResponseMessage> createProject(@RequestBody CreateProjectRequestDTO createProjectRequestDTO) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+        
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         int projectId = projectService.createProject(createProjectRequestDTO);
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("projectId", projectId);
+        responseMap.put("createProject", projectId);
 
         return ResponseEntity
                 .ok()
@@ -48,11 +49,11 @@ public class ProjectController {
     @PutMapping("/modify")
     public ResponseEntity<ResponseMessage> modifyProject(@RequestBody ModifyProjectHistoryDTO modifyProjectHistoryDTO) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+        
         int projectId = projectService.modifyProject(modifyProjectHistoryDTO);
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("projectId", projectId);
+        responseMap.put("modifyProject", projectId);
 
         return ResponseEntity
                 .ok()
@@ -62,24 +63,34 @@ public class ProjectController {
 
     /* 프로젝트 일정 10등분 */
     @GetMapping("/workingDaysDivideTen")
-    public ResponseEntity<List<LocalDate>> divideWorkingDays(
+    public ResponseEntity<ResponseMessage> divideWorkingDays(
         @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate startDate,
         @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate endDate
     ) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+        
         List<LocalDate> dividedDates = projectService.divideWorkingDaysIntoTen(startDate, endDate);
-        return ResponseEntity.ok(dividedDates);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("workingDaysDivideTen", dividedDates);
+        
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "프로젝트 일정 10등분 성공", responseMap));
     }
+
     // 프로젝트 복사(프로젝트, 일정)
     @PostMapping("/copy/{copyProjectId}")
     public ResponseEntity<ResponseMessage> copyProject(@PathVariable int copyProjectId) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         int newProjectId = projectService.copyProject(copyProjectId);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("newProjectId", newProjectId);
+        responseMap.put("copyProject", newProjectId);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/org/omoknoone/ppm/domain/project/controller/ProjectHistoryController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/controller/ProjectHistoryController.java
@@ -1,12 +1,17 @@
 package org.omoknoone.ppm.domain.project.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
+import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.project.dto.ProjectHistoryDTO;
 import org.omoknoone.ppm.domain.project.service.ProjectHistoryService;
 import org.omoknoone.ppm.domain.project.vo.ResponseProjectHistory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,13 +31,21 @@ public class ProjectHistoryController {
 
 	// 프로젝트 수정 내역 조회
 	@GetMapping("/view/{projectId}")
-	public ResponseEntity<List<ResponseProjectHistory>> viewProjectHistory(@PathVariable Integer projectId) {
+	public ResponseEntity<ResponseMessage> viewProjectHistory(@PathVariable Integer projectId) {
+
+		HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
 		List<ProjectHistoryDTO> projectHistoryDTOList = projectHistoryService.viewProjectHistory(projectId);
 		List<ResponseProjectHistory> responseProjectHistoryList = modelMapper.map(projectHistoryDTOList,
 			new TypeToken<List<ProjectHistoryDTO>>() {}.getType());
 
-		return ResponseEntity.status(HttpStatus.OK).body(responseProjectHistoryList);
+		Map<String, Object> responseMap = new HashMap<>();
+		responseMap.put("viewProjectHistory", responseProjectHistoryList);
+
+		return ResponseEntity
+				.ok()
+				.headers(headers)
+				.body(new ResponseMessage(200, "프로젝트 수정 내역 조회 성공", responseMap));
 
 	}
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/controller/GraphController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/controller/GraphController.java
@@ -1,11 +1,16 @@
 package org.omoknoone.ppm.domain.projectDashboard.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.omoknoone.ppm.common.HttpHeadersCreator;
+import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.projectDashboard.aggregate.Graph;
 import org.omoknoone.ppm.domain.projectDashboard.dto.GraphDTO;
 import org.omoknoone.ppm.domain.projectDashboard.service.GraphService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,11 +33,20 @@ public class GraphController {
 
 	// projectId로 graph에 들어갈 JSON 데이터 조회
 	@GetMapping("/{projectId}/{type}")
-	public GraphDTO viewProjectDashboardByProjectId(@PathVariable String projectId, @PathVariable String type) {
+	public ResponseEntity<ResponseMessage> viewProjectDashboardByProjectId(@PathVariable String projectId,
+																		   @PathVariable String type) {
+
+		HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
 		GraphDTO projectDashboard = graphService.viewProjectDashboardByProjectId(projectId, type);
 
-		return ResponseEntity.ok(projectDashboard).getBody();
+		Map<String, Object> responseMap = new HashMap<>();
+		responseMap.put("viewProjectDashboardByProjectId", projectDashboard);
+
+		return ResponseEntity
+				.ok()
+				.headers(headers)
+				.body(new ResponseMessage(200, "회원 검색 성공", responseMap));
 	}
 
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/controller/ProjectDashboardController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/controller/ProjectDashboardController.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.modelmapper.ModelMapper;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.projectDashboard.dto.ProjectDashboardDTO;
 import org.omoknoone.ppm.domain.projectDashboard.service.ProjectDashboardService;
@@ -34,13 +35,12 @@ public class ProjectDashboardController {
 	@PutMapping("/set")
 	public ResponseEntity<ResponseMessage> setDashboard(@RequestBody ProjectDashboardDTO requestDTO) {
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+		HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
 		Integer projectDashboardId = projectDashboardService.setDashboardLayout(requestDTO);
 
 		Map<String, Object> responseMap = new HashMap<>();
-		responseMap.put("result", projectDashboardId);
+		responseMap.put("setDashboard", projectDashboardId);
 
 		return ResponseEntity.status(HttpStatus.OK)
 			.headers(headers)
@@ -50,13 +50,19 @@ public class ProjectDashboardController {
 
 	// 대시보드 위치 조회
 	@GetMapping("/view/{projectId}")
-	public ResponseEntity<ResponseProjectDashboard> viewDashboard(@PathVariable Integer projectId) {
+	public ResponseEntity<ResponseMessage> viewDashboard(@PathVariable Integer projectId) {
+
+		HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
 		ProjectDashboardDTO projectDashboardDTO = projectDashboardService.viewProjectDashboardLayout(projectId);
 
 		ResponseProjectDashboard responseProjectDashboard = modelMapper.map(projectDashboardDTO, ResponseProjectDashboard.class);
 
-		return ResponseEntity.status(HttpStatus.OK).body(responseProjectDashboard);
+		Map<String, Object> responseMap = new HashMap<>();
+		responseMap.put("viewDashboard", responseProjectDashboard);
 
+		return ResponseEntity.status(HttpStatus.OK)
+				.headers(headers)
+				.body(new ResponseMessage(200, "대시보드 위치 조회 성공", responseMap));
 	}
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
@@ -3,6 +3,7 @@ package org.omoknoone.ppm.domain.projectmember.controller;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.common.annotation.Permission;
 import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
@@ -30,14 +31,14 @@ public class ProjectMemberController {
 
     @GetMapping("/list/{projectId}")
     public ResponseEntity<ResponseMessage> viewProjectMembersByProject(@PathVariable("projectId") Integer projectId) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<viewProjectMembersByProjectResponseDTO> responseDTOs
                 = projectMemberService.viewProjectMembersByProject(projectId);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("프로젝트 구성원 목록", responseDTOs);
+        responseMap.put("viewProjectMembersByProject", responseDTOs);
 
         return ResponseEntity
                 .ok()
@@ -47,13 +48,13 @@ public class ProjectMemberController {
 
     @PostMapping("/create")
     public ResponseEntity<ResponseMessage> createProjectMember(@RequestBody CreateProjectMemberRequestDTO requestDTO) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         Integer projectMemberId = projectMemberService.createProjectMember(requestDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("생성된 프로젝트 멤버 ID", projectMemberId);
+        responseMap.put("createProjectMember", projectMemberId);
 
         return ResponseEntity
                 .ok()
@@ -65,20 +66,20 @@ public class ProjectMemberController {
     public ResponseEntity<ResponseMessage> removeProjectMember(
             @PathVariable Integer projectMemberId,
             @RequestBody ModifyProjectMemberRequestDTO requestDTO) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         requestDTO.setProjectMemberId(projectMemberId);
 
         try {
             projectMemberService.removeProjectMember(requestDTO);
             Map<String, Object> responseMap = new HashMap<>();
-            responseMap.put("제외된 프로젝트 멤버 ID", projectMemberId);
+            responseMap.put("removeProjectMember", projectMemberId);
 
             return ResponseEntity
                     .ok()
                     .headers(headers)
-                    .body(new ResponseMessage(200, "구성원 제외가 완료.", responseMap));
+                    .body(new ResponseMessage(200, "구성원 제외 성공", responseMap));
         } catch (EntityNotFoundException ex) {
             return ResponseEntity
                     .status(HttpStatus.NOT_FOUND)
@@ -90,15 +91,15 @@ public class ProjectMemberController {
     public ResponseEntity<ResponseMessage> reactivateProjectMember(
             @PathVariable Integer projectMemberId,
             @RequestBody ModifyProjectMemberRequestDTO requestDTO) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         requestDTO.setProjectMemberId(projectMemberId);
 
         try {
             projectMemberService.reactivateProjectMember(requestDTO);
             Map<String, Object> responseMap = new HashMap<>();
-            responseMap.put("재활성화된 프로젝트 멤버 ID", projectMemberId);
+            responseMap.put("reactivateProjectMember", projectMemberId);
 
             return ResponseEntity
                     .ok()
@@ -117,14 +118,14 @@ public class ProjectMemberController {
 
     @PutMapping("/modify/{projectMemberId}")
     public ResponseEntity<ResponseMessage> modifyProjectMember(@RequestBody ModifyProjectMemberRequestDTO requestDTO) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         try {
             Integer projectMemberId = projectMemberService.modifyProjectMember(requestDTO);
 
             Map<String, Object> responseMap = new HashMap<>();
-            responseMap.put("수정된 프로젝트 멤버 ID", projectMemberId);
+            responseMap.put("modifyProjectMember", projectMemberId);
 
             return ResponseEntity
                     .ok()

--- a/src/main/java/org/omoknoone/ppm/domain/requirements/controller/RequirementsHistoryController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/requirements/controller/RequirementsHistoryController.java
@@ -1,15 +1,20 @@
 package org.omoknoone.ppm.domain.requirements.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
+import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.requirements.aggregate.RequirementsHistory;
 import org.omoknoone.ppm.domain.requirements.dto.RequirementsHistoryDTO;
 import org.omoknoone.ppm.domain.requirements.service.RequirementsHistoryService;
 import org.omoknoone.ppm.domain.requirements.vo.RequestCreateRequirementsHistory;
 import org.omoknoone.ppm.domain.requirements.vo.ResponseRequirementHistory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,12 +52,21 @@ public class RequirementsHistoryController {
 
 	/* 요구사항Id를 통한 요구사항 수정내역 조회 */
 	@GetMapping("view/{requirementsId}")
-	public ResponseEntity<ResponseRequirementHistory> viewRequirementHistoryByfScheduleId(@PathVariable Long requirementsId){
+	public ResponseEntity<ResponseMessage> viewRequirementHistoryByfScheduleId(@PathVariable Long requirementsId){
+
+		HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
 		List<RequirementsHistoryDTO> requirementsHistoryDTOList =
 			requirementsHistoryService.viewRequirementHistoryList(requirementsId);
 		ResponseRequirementHistory requirementHistoryList =
 			new ResponseRequirementHistory(requirementsHistoryDTOList);
 
-		return ResponseEntity.ok(requirementHistoryList);
+		Map<String, Object> responseMap = new HashMap<>();
+		responseMap.put("viewRequirementHistoryByfScheduleId", requirementHistoryList);
+
+		return ResponseEntity
+				.ok()
+				.headers(headers)
+				.body(new ResponseMessage(200, "요구사항 수정내역 조회 성공", responseMap));
 	}
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.schedule.aggregate.Schedule;
 import org.omoknoone.ppm.domain.schedule.dto.CreateScheduleDTO;
@@ -49,7 +50,9 @@ public class ScheduleController {
 
     /* 일정 등록 */
     @PostMapping("/create")
-    public ResponseEntity<ResponseSchedule> createSchedule(@RequestBody RequestSchedule requestSchedule) {
+    public ResponseEntity<ResponseMessage> createSchedule(@RequestBody RequestSchedule requestSchedule) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         CreateScheduleDTO createScheduleDTO = modelMapper.map(requestSchedule, CreateScheduleDTO.class);
@@ -58,67 +61,113 @@ public class ScheduleController {
 
         ResponseSchedule responseSchedule = modelMapper.map(newSchedule, ResponseSchedule.class);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseSchedule);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("createSchedule", responseSchedule);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 등록 성공", responseMap));
     }
 
     /* 일정 상세 조회 */
     @GetMapping("/view/{scheduleId}")
-    public ResponseEntity<ResponseSchedule> viewSchedule(@PathVariable("scheduleId") Long scheduleId) {
+    public ResponseEntity<ResponseMessage> viewSchedule(@PathVariable("scheduleId") Long scheduleId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         ScheduleDTO scheduleDTO = scheduleService.viewSchedule(scheduleId);
 
         ResponseSchedule responseSchedule = modelMapper.map(scheduleDTO, ResponseSchedule.class);
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseSchedule);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewSchedule", responseSchedule);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 상세 조회 성공", responseMap));
     }
 
     /* 프로젝트별 일정 목록 조회 */
     @GetMapping("/list/{projectId}")
-    public ResponseEntity<List<ResponseSchedule>> viewScheduleByProject(@PathVariable("projectId") Long projectId) {
+    public ResponseEntity<ResponseMessage> viewScheduleByProject(@PathVariable("projectId") Long projectId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<ScheduleDTO> scheduleDTOList = scheduleService.viewScheduleByProject(projectId);
         List<ResponseSchedule> responseScheduleList = modelMapper.map(scheduleDTOList,
             new TypeToken<List<ScheduleDTO>>() {
             }.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseScheduleList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewScheduleByProject", responseScheduleList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "프로젝트별 일정 목록 조회 성공", responseMap));
     }
 
     /* 일정 오름차순, 내림차순 목록 조회 (시작일 기준) */
     @GetMapping("/list/{projectId}/{sort}")
-    public ResponseEntity<List<ResponseSchedule>> viewScheduleOrderBy(@PathVariable("projectId") Long projectId,
+    public ResponseEntity<ResponseMessage> viewScheduleOrderBy(@PathVariable("projectId") Long projectId,
         @PathVariable("sort") String sort) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<ScheduleDTO> scheduleDTOList = scheduleService.viewScheduleOrderBy(projectId, sort);
         List<ResponseSchedule> responseScheduleList = modelMapper.map(scheduleDTOList,
             new TypeToken<List<ScheduleDTO>>() {
             }.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseScheduleList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewScheduleOrderBy", responseScheduleList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 조회 성공", responseMap));
     }
 
     /* 일정 임박일순 목록 조회 */
     @GetMapping("/nearstart/{projectId}")
-    public ResponseEntity<List<ResponseSchedule>> viewScheduleNearByStart(@PathVariable("projectId") Long projectId) {
+    public ResponseEntity<ResponseMessage> viewScheduleNearByStart(@PathVariable("projectId") Long projectId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<ScheduleDTO> scheduleDTOList = scheduleService.viewScheduleNearByStart(projectId);
         List<ResponseSchedule> responseScheduleList = modelMapper.map(scheduleDTOList,
             new TypeToken<List<ScheduleDTO>>() {
             }.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseScheduleList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewScheduleNearByStart", responseScheduleList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 임박일순 조회 성공", responseMap));
     }
 
     /* 일정 마감일순 목록 조회 */
     @GetMapping("/nearend/{projectId}")
-    public ResponseEntity<List<ResponseSchedule>> viewScheduleNearByEnd(@PathVariable("projectId") Long projectId) {
+    public ResponseEntity<ResponseMessage> viewScheduleNearByEnd(@PathVariable("projectId") Long projectId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<ScheduleDTO> scheduleDTOList = scheduleService.viewScheduleNearByEnd(projectId);
         List<ResponseSchedule> responseScheduleList = modelMapper.map(scheduleDTOList,
             new TypeToken<List<ScheduleDTO>>() {
             }.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseScheduleList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewScheduleNearByEnd", responseScheduleList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 마감일순 목록 조회 성공", responseMap));
     }
 
     /* 일정 수정 */
@@ -127,19 +176,19 @@ public class ScheduleController {
             @PathVariable Long scheduleId,
             @RequestBody RequestModifyScheduleDTO requestModifyScheduleDTO) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         requestModifyScheduleDTO.setScheduleId(scheduleId);
 
         Long modifiedScheduleId = scheduleService.modifySchedule(requestModifyScheduleDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("scheduleId", modifiedScheduleId);
+        responseMap.put("modifySchedule", modifiedScheduleId);
 
-        return ResponseEntity.status(HttpStatus.OK)
-            .headers(headers)
-            .body(new ResponseMessage(200, "일정 수정 성공", responseMap));
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 수정 성공", responseMap));
     }
 
     /* 일정 제거(soft delete) */
@@ -148,52 +197,92 @@ public class ScheduleController {
             @PathVariable Long scheduleId,
             @RequestBody RequestModifyScheduleDTO requestModifyScheduleDTO){
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         requestModifyScheduleDTO.setScheduleId(scheduleId);
 
         scheduleService.removeSchedule(requestModifyScheduleDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", scheduleId);
+        responseMap.put("removeSchedule", scheduleId);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-            .headers(headers)
-            .body(new ResponseMessage(204, "일정 삭제 성공", responseMap));
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .headers(headers)
+                .body(new ResponseMessage(204, "일정 삭제 성공", responseMap));
     }
 
     /* Title을 통한 일정 검색 */
     @GetMapping("/search/{scheduleTitle}")
-    public ResponseEntity<ResponseSearchScheduleList> searchScheduleByTitle(@PathVariable String scheduleTitle){
+    public ResponseEntity<ResponseMessage> searchScheduleByTitle(@PathVariable String scheduleTitle){
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
         List<SearchScheduleListDTO> searchScheduleListDTO = scheduleService.searchSchedulesByTitle(scheduleTitle);
         ResponseSearchScheduleList searchResult = new ResponseSearchScheduleList(searchScheduleListDTO);
-        return ResponseEntity.ok(searchResult);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("searchScheduleByTitle", searchResult);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 검색 성공", responseMap));
     }
 
     /* 일정 상태값에 따른 일정 목록 확인 */
     @GetMapping("/status")
-    public List<Schedule> getSchedulesByStatusCodes(@RequestParam List<Long> codeIds) {
-        return scheduleService.getSchedulesByStatusCodes(codeIds);
+    public ResponseEntity<ResponseMessage> getSchedulesByStatusCodes(@RequestParam List<Long> codeIds) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
+        // TODO. DTO로 변경
+        List<Schedule> schedules = scheduleService.getSchedulesByStatusCodes(codeIds);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("getSchedulesByStatusCodes", schedules);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정 목록 조회 성공", responseMap));
     }
 
     /* 날짜 설정 범위에 따른 일정 확인 */
     @GetMapping("/range")
-    public ResponseEntity<List<ResponseSchedule>> viewSchedulesByDateRange(
+    public ResponseEntity<ResponseMessage> viewSchedulesByDateRange(
         @RequestParam("startDate") LocalDate startDate,
         @RequestParam("endDate") LocalDate endDate) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<ScheduleDTO> scheduleDTOList = scheduleService.viewSchedulesByDateRange(startDate, endDate);
         List<ResponseSchedule> responseScheduleList =
             modelMapper.map(scheduleDTOList, new TypeToken<List<ResponseSchedule>>() {}.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseScheduleList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("searchEmployeeByName", responseScheduleList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "날짜에 따른 일정 조회 성공", responseMap));
     }
 
     /* 해당 일자가 포함된 주에 끝나야할 일정 목록 조회 */
     @GetMapping("/thisweek")
-    public ResponseEntity<List<Schedule>> findSchedulesForThisWeek(){
+    public ResponseEntity<ResponseMessage> findSchedulesForThisWeek(){
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
         List<Schedule> schedules = scheduleService.getSchedulesForThisWeek();
-        return ResponseEntity.ok(schedules);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("findSchedulesForThisWeek", schedules);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "끝나야할 일정 목록 조회 성공", responseMap));
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleHistoryController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleHistoryController.java
@@ -3,6 +3,8 @@ package org.omoknoone.ppm.domain.schedule.controller;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
+import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.schedule.aggregate.ScheduleHistory;
 import org.omoknoone.ppm.domain.schedule.dto.CreateScheduleHistoryDTO;
 import org.omoknoone.ppm.domain.schedule.dto.RequestCreateScheduleHistoryDTO;
@@ -12,11 +14,14 @@ import org.omoknoone.ppm.domain.schedule.vo.RequestSchedule;
 import org.omoknoone.ppm.domain.schedule.vo.ResponseSchedule;
 import org.omoknoone.ppm.domain.schedule.vo.ResponseScheduleHistory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/scheduleHistories")
@@ -47,13 +52,21 @@ public class ScheduleHistoryController {
 
     /* 일정 수정 내역 조회 */
     @GetMapping("/view/{scheduleId}")
-    public ResponseEntity<List<ResponseScheduleHistory>> viewSchedule(@PathVariable("scheduleId") Long scheduleId) {
+    public ResponseEntity<ResponseMessage> viewSchedule(@PathVariable("scheduleId") Long scheduleId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<ScheduleHistoryDTO> scheduleHistoryDTOList = scheduleHistoryService.viewScheduleHistory(scheduleId);
         List<ResponseScheduleHistory> responseScheduleHistoryList = modelMapper.map(scheduleHistoryDTOList,
                 new TypeToken<List<ScheduleHistoryDTO>>() {}.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseScheduleHistoryList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewSchedule", responseScheduleHistoryList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "회원 검색 성공", responseMap));
     }
 
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleRequirementMapController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleRequirementMapController.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.schedule.aggregate.ScheduleRequirementMap;
 import org.omoknoone.ppm.domain.schedule.dto.CreateScheduleRequirementMapDTO;
@@ -44,8 +45,10 @@ public class ScheduleRequirementMapController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<ResponseScheduleRequirementMap> createScheduleRequirementsMap(@RequestBody
+    public ResponseEntity<ResponseMessage> createScheduleRequirementsMap(@RequestBody
     RequestCreateScheduleRequirementMapDTO requestCreateScheduleRequirementMapDTO) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         CreateScheduleRequirementMapDTO createScheduleRequirementMapDTO = modelMapper.map(
@@ -57,12 +60,20 @@ public class ScheduleRequirementMapController {
         ResponseScheduleRequirementMap responseScheduleRequirementMap = modelMapper.map(newScheduleRequirementMap,
             ResponseScheduleRequirementMap.class);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseScheduleRequirementMap);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("createScheduleRequirementsMap", responseScheduleRequirementMap);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정요구사항맵 등록 성공", responseMap));
     }
 
     @GetMapping("/view/{scheduleId}")
-    public ResponseEntity<List<ResponseScheduleRequirementMap>> viewScheduleRequirementsMap(
+    public ResponseEntity<ResponseMessage> viewScheduleRequirementsMap(
         @PathVariable("scheduleId") Long scheduleId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<ScheduleRequirementMapDTO> scheduleRequirementMapDTOList = scheduleRequirementMapService.viewScheduleRequirementsMap(
             scheduleId);
@@ -72,19 +83,24 @@ public class ScheduleRequirementMapController {
             new TypeToken<List<ScheduleRequirementMap>>() {
             }.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseScheduleRequirementMapList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewScheduleRequirementsMap", responseScheduleRequirementMapList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정요구사항맵 조회 성공", responseMap));
     }
 
     @DeleteMapping("/remove/{requirementsMapId}")
     public ResponseEntity<ResponseMessage> removeStakeholder(@PathVariable("requirementsMapId") Long requirementsMapId){
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
-
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+        
         Long removedRequirementsMapId = scheduleRequirementMapService.removeScheduleRequirementsMap(requirementsMapId);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", removedRequirementsMapId);
+        responseMap.put("removeStakeholder", removedRequirementsMapId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .headers(headers)

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
@@ -72,5 +72,5 @@ public interface ScheduleService {
     List<ScheduleDTO> viewSchedulesByDateRange(LocalDate startDate, LocalDate endDate);
 
     /* 해당 일자가 포함된 주에 끝나야할 일정 목록 조회 */
-	List<Schedule> getSchedulesForThisWeek();
+    List<Schedule> getSchedulesForThisWeek();
 }

--- a/src/main/java/org/omoknoone/ppm/domain/stakeholders/controller/StakeholdersController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/stakeholders/controller/StakeholdersController.java
@@ -4,6 +4,7 @@ package org.omoknoone.ppm.domain.stakeholders.controller;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.stakeholders.aggregate.Stakeholders;
 import org.omoknoone.ppm.domain.stakeholders.dto.*;
@@ -36,7 +37,9 @@ public class StakeholdersController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<ResponseStakeholders> createStakeholder(@RequestBody RequestCreateStakeholdersDTO requestCreateStakeholdersDTO) {
+    public ResponseEntity<ResponseMessage> createStakeholder(@RequestBody RequestCreateStakeholdersDTO requestCreateStakeholdersDTO) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         CreateStakeholdersDTO createStakeholdersDTO = modelMapper.map(requestCreateStakeholdersDTO, CreateStakeholdersDTO.class);
@@ -45,24 +48,37 @@ public class StakeholdersController {
 
         ResponseStakeholders responseStakeholders = modelMapper.map(newStakeholders, ResponseStakeholders.class);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseStakeholders);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("createStakeholder", responseStakeholders);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "이해관계자 등록 성공", responseMap));
     }
 
     @GetMapping("/view/{scheduleId}")
-    public ResponseEntity<List<ResponseStakeholders>> viewStakeholders(@PathVariable("scheduleId") Long scheduleId){
+    public ResponseEntity<ResponseMessage> viewStakeholders(@PathVariable("scheduleId") Long scheduleId){
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<StakeholdersDTO> stakeholdersDTOList = stakeholdersService.viewStakeholders(scheduleId);
         List<ResponseStakeholders> responseStakeholdersList = modelMapper.map(stakeholdersDTOList,
                 new TypeToken<List<Stakeholders>>(){}.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseStakeholdersList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewStakeholders", responseStakeholdersList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "이해관계자 조회 성공", responseMap));
     }
 
     @PutMapping("/modify")
     public ResponseEntity<ResponseMessage> modifyStakeholder(@RequestBody RequestModifyStakeholdersDTO requestModifyStakeholdersDTO) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         ModifyStakeholdersDTO modifyStakeholdersDTO = modelMapper.map(requestModifyStakeholdersDTO, ModifyStakeholdersDTO.class);
@@ -70,9 +86,10 @@ public class StakeholdersController {
         Long stakeholdersId = stakeholdersService.modifyStakeholder(modifyStakeholdersDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", stakeholdersId);
+        responseMap.put("modifyStakeholder", stakeholdersId);
 
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity
+                .ok()
                 .headers(headers)
                 .body(new ResponseMessage(200, "이해관계자 수정 성공", responseMap));
     }
@@ -80,15 +97,15 @@ public class StakeholdersController {
     @DeleteMapping("/remove/{stakeholdersId}")
     public ResponseEntity<ResponseMessage> removeStakeholder(@PathVariable("stakeholdersId") Long stakeholdersId) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         Long removedStakeholdersId = stakeholdersService.removeStakeholder(stakeholdersId);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", removedStakeholdersId);
+        responseMap.put("removeStakeholder", removedStakeholdersId);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+        return ResponseEntity
+                .ok()
                 .headers(headers)
                 .body(new ResponseMessage(204, "이해관계자 삭제 성공", responseMap));
     }

--- a/src/main/java/org/omoknoone/ppm/domain/task/controller/TaskController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/task/controller/TaskController.java
@@ -3,6 +3,7 @@ package org.omoknoone.ppm.domain.task.controller;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.task.aggregate.Task;
 import org.omoknoone.ppm.domain.task.dto.*;
@@ -35,7 +36,9 @@ public class TaskController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<ResponseTask> createTask(@RequestBody RequestCreateTaskDTO requestCreateTaskDTO) {
+    public ResponseEntity<ResponseMessage> createTask(@RequestBody RequestCreateTaskDTO requestCreateTaskDTO) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         CreateTaskDTO createTaskDTO = modelMapper.map(requestCreateTaskDTO, CreateTaskDTO.class);
@@ -44,35 +47,56 @@ public class TaskController {
 
         ResponseTask responseTask = modelMapper.map(newTask, ResponseTask.class);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseTask);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("createTask", responseTask);
+        
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(201, "업무 등록 성공", responseMap));
     }
 
     @GetMapping("/view/{taskId}")
-    public ResponseEntity<ResponseTask> viewTask(@PathVariable("taskId") Long taskId) {
+    public ResponseEntity<ResponseMessage> viewTask(@PathVariable("taskId") Long taskId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         TaskDTO taskDTO = taskService.viewTask(taskId);
 
         ResponseTask responseTask = modelMapper.map(taskDTO, ResponseTask.class);
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseTask);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewTask", responseTask);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "업무 조회 성공", responseMap));
     }
 
     @GetMapping("/list/{scheduleId}")
-    public ResponseEntity<List<ResponseTask>> viewScheduleTask(@PathVariable("scheduleId") Long scheduleId) {
+    public ResponseEntity<ResponseMessage> viewScheduleTask(@PathVariable("scheduleId") Long scheduleId) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         List<TaskDTO> taskDTOList = taskService.viewScheduleTask(scheduleId);
         List<ResponseTask> responseTaskList = modelMapper.map(taskDTOList, new TypeToken<List<TaskDTO>>() {
         }.getType());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseTaskList);
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewScheduleTask", responseTaskList);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "일정에 따른 업무 조회 성공", responseMap));
     }
 
 
     @PutMapping("/modify")
     public ResponseEntity<ResponseMessage> modifyTask(@RequestBody RequestModifyTaskDTO requestModifyTaskDTO) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         ModifyTaskDTO modifyTaskDTO = modelMapper.map(requestModifyTaskDTO, ModifyTaskDTO.class);
@@ -80,9 +104,10 @@ public class TaskController {
         Long taskId = taskService.modifyTask(modifyTaskDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", taskId);
+        responseMap.put("modifyTask", taskId);
 
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity
+                .ok()
                 .headers(headers)
                 .body(new ResponseMessage(200, "업무 수정 성공", responseMap));
     }
@@ -90,15 +115,15 @@ public class TaskController {
     @DeleteMapping("/remove/{taskId}")
     public ResponseEntity<ResponseMessage> removeTask(@PathVariable("taskId") Long taskId) {
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
         Long removedTaskId = taskService.removeTask(taskId);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("result", removedTaskId);
+        responseMap.put("removeTask", removedTaskId);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+        return ResponseEntity
+                .ok()
                 .headers(headers)
                 .body(new ResponseMessage(204, "업무 삭제 성공", responseMap));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #125 

## 📝작업 내용

- 자주 사용되는 Header부분은 static 메소드로 구현
- ResponseMessage를 사용하지 않는 컨트롤러의 반환 형태를 ResponseMessage를 사용하여 반환 상태값을 전달 할 수 있게 변경
- result 안에 담기는 Key값은 메소드명으로 통일
```java
public ResponseEntity<ResponseMessage> createNotification(@RequestBody NotificationRequestDTO requestDTO) {

        HttpHeaders headers = HttpHeadersCreator.createHeaders();

        NotificationResponseDTO responseDTO = notificationService.createNotification(requestDTO);

        Map<String, Object> responseMap = new HashMap<>();
        responseMap.put("createNotification", responseDTO);       // 반환 Key값은 메소드명과 일치

        return ResponseEntity
                .ok()
                .headers(headers)
                .body(new ResponseMessage(200, "알림 생성 성공", responseMap));
    }
```

## 💬리뷰 요구사항(선택)

> Controller에 aggregate이 사용된 부분은 추후에 변경할 예정
