### PR TITLE
[PR] 프로젝트 생성 기능 로직에 맞게 구현

### DIFF
--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/repository/CommonCodeRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/repository/CommonCodeRepository.java
@@ -11,4 +11,6 @@ public interface CommonCodeRepository extends JpaRepository<CommonCode, Long> {
     // 외래 키를 기준으로 CommonCode 검색
     List<CommonCode> findByCodeGroupId(Long codeGroupId);
 
+    // CodeName을 기준으로 CommonCode 검색
+    CommonCode findByCodeName(String codeName);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeService.java
@@ -16,4 +16,6 @@ public interface CommonCodeService {
      CommonCodeGroupResponseDTO viewCommonCodeGroupById(Long groupId);
 
      List<CommonCodeResponseDTO> viewCommonCodesByGroupName(String codeGroupName);
+
+     CommonCodeResponseDTO viewCommonCodeByCodeName(String codeName);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/commoncode/service/CommonCodeServiceImpl.java
@@ -1,6 +1,7 @@
 package org.omoknoone.ppm.domain.commoncode.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.modelmapper.ModelMapper;
 import org.omoknoone.ppm.domain.commoncode.aggregate.CommonCode;
 import org.omoknoone.ppm.domain.commoncode.aggregate.CommonCodeGroup;
 import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeResponseDTO;
@@ -20,12 +21,14 @@ public class CommonCodeServiceImpl implements CommonCodeService {
 
     private final CommonCodeRepository commonCodeRepository;
     private final CommonCodeGroupRepository commonCodeGroupRepository;
+    private final ModelMapper modelMapper;
 
     @Autowired
     public CommonCodeServiceImpl(CommonCodeRepository commonCodeRepository,
-                                 CommonCodeGroupRepository commonCodeGroupRepository) {
+                                 CommonCodeGroupRepository commonCodeGroupRepository, ModelMapper modelMapper) {
         this.commonCodeRepository = commonCodeRepository;
         this.commonCodeGroupRepository = commonCodeGroupRepository;
+        this.modelMapper = modelMapper;
     }
 
     @Override
@@ -108,5 +111,14 @@ public class CommonCodeServiceImpl implements CommonCodeService {
                         code.getCodeName(),
                         code.getCodeDescription()))
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public CommonCodeResponseDTO viewCommonCodeByCodeName(String codeName) {
+
+        CommonCode code = commonCodeRepository.findByCodeName(codeName);
+
+        return modelMapper.map(code, CommonCodeResponseDTO.class);
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/project/aggregate/Project.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/aggregate/Project.java
@@ -87,4 +87,8 @@ public class Project {
             this.projectStatus = modifyProjectRequestDTO.getProjectStatus();
         }
     }
+
+    public void saveProjectStatus(int projectStatus) {
+        this.projectStatus = projectStatus;
+    }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/project/dto/CreateProjectRequestDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/dto/CreateProjectRequestDTO.java
@@ -14,10 +14,10 @@ public class CreateProjectRequestDTO {
     private String projectTitle;
     private LocalDate projectStartDate;
     private LocalDate projectEndDate;
-    private int projectStatus;
+    private String projectStatus;
 
     @Builder
-    public CreateProjectRequestDTO(String projectTitle, LocalDate projectStartDate, LocalDate projectEndDate, int projectStatus) {
+    public CreateProjectRequestDTO(String projectTitle, LocalDate projectStartDate, LocalDate projectEndDate, String projectStatus) {
         this.projectTitle = projectTitle;
         this.projectStartDate = projectStartDate;
         this.projectEndDate = projectEndDate;

--- a/src/main/java/org/omoknoone/ppm/domain/project/dto/CreateProjectRequestDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/dto/CreateProjectRequestDTO.java
@@ -15,12 +15,14 @@ public class CreateProjectRequestDTO {
     private LocalDate projectStartDate;
     private LocalDate projectEndDate;
     private String projectStatus;
+    private String employeeId;
 
     @Builder
-    public CreateProjectRequestDTO(String projectTitle, LocalDate projectStartDate, LocalDate projectEndDate, String projectStatus) {
+    public CreateProjectRequestDTO(String projectTitle, LocalDate projectStartDate, LocalDate projectEndDate, String projectStatus, String employeeId) {
         this.projectTitle = projectTitle;
         this.projectStartDate = projectStartDate;
         this.projectEndDate = projectEndDate;
         this.projectStatus = projectStatus;
+        this.employeeId = employeeId;
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/service/ProjectServiceImpl.java
@@ -3,6 +3,8 @@ package org.omoknoone.ppm.domain.project.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeGroupResponseDTO;
+import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeResponseDTO;
 import org.omoknoone.ppm.domain.commoncode.service.CommonCodeService;
 import org.omoknoone.ppm.domain.holiday.aggregate.Holiday;
 import org.omoknoone.ppm.domain.holiday.repository.HolidayRepository;
@@ -43,7 +45,19 @@ public class ProjectServiceImpl implements ProjectService {
     @Transactional
     @Override
     public int createProject(CreateProjectRequestDTO createProjectRequestDTO) {
-        Project project = modelMapper.map(createProjectRequestDTO, Project.class);
+
+        CommonCodeResponseDTO commonCodeResponseDTO = commonCodeService.
+                                                viewCommonCodeByCodeName(createProjectRequestDTO.getProjectStatus());
+        int projectStatus = Integer.parseInt(commonCodeResponseDTO.getCodeId().toString());
+
+        Project project = Project
+                .builder()
+                .projectTitle(createProjectRequestDTO.getProjectTitle())
+                .projectStartDate(createProjectRequestDTO.getProjectStartDate())
+                .projectEndDate(createProjectRequestDTO.getProjectEndDate())
+                .projectIsDeleted(false)
+                .build();
+        project.saveProjectStatus(projectStatus);
 
         projectRepository.save(project);
 

--- a/src/main/java/org/omoknoone/ppm/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/project/service/ProjectServiceImpl.java
@@ -3,7 +3,6 @@ package org.omoknoone.ppm.domain.project.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeGroupResponseDTO;
 import org.omoknoone.ppm.domain.commoncode.dto.CommonCodeResponseDTO;
 import org.omoknoone.ppm.domain.commoncode.service.CommonCodeService;
 import org.omoknoone.ppm.domain.holiday.aggregate.Holiday;
@@ -15,9 +14,12 @@ import org.omoknoone.ppm.domain.project.dto.ViewProjectResponseDTO;
 import org.omoknoone.ppm.domain.project.repository.ProjectRepository;
 import org.omoknoone.ppm.domain.project.vo.ProjectModificationResult;
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMember;
+import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.service.ProjectMemberService;
 import org.omoknoone.ppm.domain.schedule.aggregate.Schedule;
+import org.omoknoone.ppm.domain.schedule.dto.CreateScheduleDTO;
 import org.omoknoone.ppm.domain.schedule.repository.ScheduleRepository;
+import org.omoknoone.ppm.domain.schedule.service.ScheduleService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,19 +39,21 @@ public class ProjectServiceImpl implements ProjectService {
     private final ProjectRepository projectRepository;
     private final HolidayRepository holidayRepository;
     private final ScheduleRepository scheduleRepository;
+    private final ScheduleService scheduleService;
     private final ProjectMemberService projectMemberService;
     private final CommonCodeService commonCodeService;
-    // private final GraphService graphService;
     private final ModelMapper modelMapper;
 
     @Transactional
     @Override
     public int createProject(CreateProjectRequestDTO createProjectRequestDTO) {
 
+        // 프로젝트 상태 코드 조회
         CommonCodeResponseDTO commonCodeResponseDTO = commonCodeService.
                                                 viewCommonCodeByCodeName(createProjectRequestDTO.getProjectStatus());
         int projectStatus = Integer.parseInt(commonCodeResponseDTO.getCodeId().toString());
 
+        // 프로젝트 생성
         Project project = Project
                 .builder()
                 .projectTitle(createProjectRequestDTO.getProjectTitle())
@@ -60,6 +64,35 @@ public class ProjectServiceImpl implements ProjectService {
         project.saveProjectStatus(projectStatus);
 
         projectRepository.save(project);
+
+        // 기본 일정 생성
+        Long scheduleStatus = Long.valueOf(commonCodeService.viewCommonCodeByCodeName("준비").getCodeId().toString());
+
+        CreateScheduleDTO createScheduleDTO = CreateScheduleDTO.builder()
+                .scheduleProjectId(Long.valueOf(project.getProjectId()))
+                .scheduleTitle("프로젝트 시작")
+                .scheduleContent("기본 일정")
+                .scheduleDepth(1)
+                .scheduleStatus(scheduleStatus)
+                .scheduleStartDate(project.getProjectStartDate())
+                .scheduleEndDate(project.getProjectStartDate())
+                .scheduleIsDeleted(false)
+                .build();
+
+
+        Long scheduleId = scheduleService.createSchedule(createScheduleDTO).getScheduleId();
+
+        // 방금 만든 프로젝트의 구성원으로 생성자의 정보를 PM으로 등록
+        int pmRoleId = Integer.parseInt(commonCodeService.viewCommonCodeByCodeName("PM").getCodeId().toString());
+
+        CreateProjectMemberRequestDTO createProjectMemberRequestDTO = CreateProjectMemberRequestDTO.builder()
+                .projectMemberEmployeeId(createProjectRequestDTO.getEmployeeId())
+                .projectMemberProjectId(project.getProjectId())
+                .projectMemberRoleId(pmRoleId)
+                .permissionScheduleId(scheduleId)
+                .build();
+
+        projectMemberService.createProjectMember(createProjectMemberRequestDTO);
 
         int projectId = project.getProjectId();
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
@@ -4,21 +4,25 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
 import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
+@ToString
 @NoArgsConstructor
 @Getter
 @Entity
 @Table(name = "project_member")
 public class ProjectMember {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "project_member_id", nullable = false)
     private Integer projectMemberId;
 
-    @CreatedDate
+    @CreationTimestamp
     @Column(name = "project_member_created_date", nullable = false, length = 30)
     private String projectMemberCreatedDate;
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/CreateProjectMemberRequestDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/CreateProjectMemberRequestDTO.java
@@ -1,17 +1,22 @@
 package org.omoknoone.ppm.domain.projectmember.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
+@ToString
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter @Setter
 public class CreateProjectMemberRequestDTO {
 
     private Integer projectMemberProjectId;
     private Integer projectMemberRoleId;
     private String projectMemberEmployeeId;
+    private Long permissionScheduleId;
 
+    @Builder
+    public CreateProjectMemberRequestDTO(Integer projectMemberProjectId, Integer projectMemberRoleId, String projectMemberEmployeeId, Long permissionScheduleId) {
+        this.projectMemberProjectId = projectMemberProjectId;
+        this.projectMemberRoleId = projectMemberRoleId;
+        this.projectMemberEmployeeId = projectMemberEmployeeId;
+        this.permissionScheduleId = permissionScheduleId;
+    }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
@@ -29,10 +29,11 @@ import org.omoknoone.ppm.domain.schedule.dto.SearchScheduleListDTO;
 import org.omoknoone.ppm.domain.schedule.dto.UpdateDataDTO;
 import org.omoknoone.ppm.domain.schedule.dto.UpdateTableDataDTO;
 import org.omoknoone.ppm.domain.schedule.repository.ScheduleRepository;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@RequiredArgsConstructor
+//@RequiredArgsConstructor
 @Service
 public class ScheduleServiceImpl implements ScheduleService {
 
@@ -41,6 +42,15 @@ public class ScheduleServiceImpl implements ScheduleService {
 	private final ScheduleRepository scheduleRepository;
 	private final ScheduleHistoryService scheduleHistoryService;
 	private final ProjectService projectService;
+
+	// TODO. 임시로 ProjectService를 Lazy로 변경하여 순환 참조 문제 해결하였으나 설계 변경 필요
+	public ScheduleServiceImpl(@Lazy ProjectService projectService, ScheduleHistoryService scheduleHistoryService, ScheduleRepository scheduleRepository, HolidayRepository holidayRepository, ModelMapper modelMapper) {
+		this.projectService = projectService;
+		this.scheduleHistoryService = scheduleHistoryService;
+		this.scheduleRepository = scheduleRepository;
+		this.holidayRepository = holidayRepository;
+		this.modelMapper = modelMapper;
+	}
 
 	@Override
 	@Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

- #21

## 📝작업 내용

> 프로젝트 생성 시 함께 이루어져야하는 로직들 구현

##### 프로젝트 생성 과정

1. 프로젝트 생성
2. 구성원 생성
3. 기본 일정 생성
4. 권한 생성

##### `createProject()`

프로젝트 생성 시 한번에 필요한 정보들이 생성되게 한곳에서 호출

##### `createProjectMember()`

일정의 ID에 맞는 구성원 생성, 구성원 정보에 맞게 권한 생성


### 📷스크린샷 (선택)



## 💬리뷰 요구사항(선택)

> 임시로 ProjectService를 Lazy로 변경하여 순환 참조 문제 해결하였으나 설계 변경 필요
> `ScheduleService`에서 `ProjectService`를 사용중인 메소드는 **일정 계산**하는 부분만 있어 일정 계산을 따로 Service 분리하게 되면 해결할 수 있을 것 같은데 분리했을 경우 문제가 생길 부분이 있을지? 아니면 더 좋은 방안이 생각나는게 있으면 댓글 부탁드립니다.