### PR TITLE
[PR] Front Schedule Sheet에 사용할 일정 조회 기능

### DIFF
--- a/src/main/java/org/omoknoone/ppm/domain/permission/dto/RoleAndSchedulesDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/permission/dto/RoleAndSchedulesDTO.java
@@ -1,0 +1,23 @@
+package org.omoknoone.ppm.domain.permission.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class RoleAndSchedulesDTO {
+    Long roleName;
+    List<Long> scheduleIdList;
+
+    @Builder
+    public RoleAndSchedulesDTO(Long roleName, List<Long> scheduleIdList) {
+        this.roleName = roleName;
+        this.scheduleIdList = scheduleIdList;
+    }
+}

--- a/src/main/java/org/omoknoone/ppm/domain/permission/repository/PermissionRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/permission/repository/PermissionRepository.java
@@ -4,10 +4,19 @@ import java.util.List;
 
 import org.omoknoone.ppm.domain.permission.aggregate.Permission;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PermissionRepository extends JpaRepository<Permission, Long> {
 
     List<Permission> findPermissionByPermissionProjectMemberId(Long projectMemberId);
 
     List<Permission> findPermissionByPermissionScheduleId(Long scheduleId);
+
+    @Query("SELECT "
+        + "p "
+        + "FROM Permission p "
+        + "JOIN ProjectMember pm ON pm.projectMemberId = p.permissionProjectMemberId "
+        + "JOIN Employee e ON e.employeeId = pm.projectMemberEmployeeId "
+        + "WHERE pm.projectMemberEmployeeId = :employeeId AND pm.projectMemberProjectId = :projectId")
+    List<Permission> findPermissionIdListByEmployeeIdAndProjectId(String employeeId, Long projectId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/permission/service/PermissionService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/permission/service/PermissionService.java
@@ -1,10 +1,12 @@
 package org.omoknoone.ppm.domain.permission.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.omoknoone.ppm.domain.permission.aggregate.Permission;
 import org.omoknoone.ppm.domain.permission.dto.CreatePermissionDTO;
 import org.omoknoone.ppm.domain.permission.dto.PermissionDTO;
+import org.omoknoone.ppm.domain.permission.dto.RoleAndSchedulesDTO;
 
 public interface PermissionService {
 
@@ -15,4 +17,6 @@ public interface PermissionService {
     List<PermissionDTO> viewSchedulePermission(Long scheduleId);
 
     Long removePermission(Long plPermissionId);
+
+    RoleAndSchedulesDTO getPermissionIdListByPermission(String employeeId, Long projectId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/permission/service/PermissionServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/permission/service/PermissionServiceImpl.java
@@ -6,12 +6,15 @@ import org.modelmapper.convention.MatchingStrategies;
 import org.omoknoone.ppm.domain.permission.aggregate.Permission;
 import org.omoknoone.ppm.domain.permission.dto.CreatePermissionDTO;
 import org.omoknoone.ppm.domain.permission.dto.PermissionDTO;
+import org.omoknoone.ppm.domain.permission.dto.RoleAndSchedulesDTO;
 import org.omoknoone.ppm.domain.permission.repository.PermissionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class PermissionServiceImpl implements PermissionService {
@@ -44,7 +47,7 @@ public class PermissionServiceImpl implements PermissionService {
     public List<PermissionDTO> viewMemberPermission(Long projectMemberId) {
 
         List<Permission> permissionList = permissionRepository
-                .findPermissionByPermissionProjectMemberId(projectMemberId);
+            .findPermissionByPermissionProjectMemberId(projectMemberId);
 
         if (permissionList == null || permissionList.isEmpty()) {
             throw new IllegalArgumentException(projectMemberId + " 구성원에 해당하는 권한이 존재하지 않습니다.");
@@ -59,7 +62,7 @@ public class PermissionServiceImpl implements PermissionService {
     public List<PermissionDTO> viewSchedulePermission(Long scheduleId) {
 
         List<Permission> permissionList = permissionRepository
-                .findPermissionByPermissionScheduleId(scheduleId);
+            .findPermissionByPermissionScheduleId(scheduleId);
 
         if (permissionList == null || permissionList.isEmpty()) {
             throw new IllegalArgumentException(scheduleId + " 일정에 연관된 권한이 존재하지 않습니다.");
@@ -74,12 +77,42 @@ public class PermissionServiceImpl implements PermissionService {
     public Long removePermission(Long permissionId) {
 
         Permission permission = permissionRepository.findById(permissionId)
-                .orElseThrow(IllegalArgumentException::new);
+            .orElseThrow(IllegalArgumentException::new);
 
         permission.remove();
 
         permissionRepository.save(permission);
 
         return permission.getPermissionId();
+    }
+
+    @Override
+    public RoleAndSchedulesDTO getPermissionIdListByPermission(String employeeId, Long projectId) {
+
+        List<Permission> permissionList = permissionRepository.
+            findPermissionIdListByEmployeeIdAndProjectId(employeeId, projectId);
+
+        if (permissionList == null || permissionList.isEmpty()) {
+            throw new IllegalArgumentException(employeeId + "의 " + projectId
+                + "프로젝트에 연관된 권한이 존재하지 않습니다.");
+        }
+
+        /* permissionList의 모든 permission에 대하여 permissionRoleName을 조회하여 제일 낮은 숫자를 조회 */
+        Long roleName = permissionList.stream()
+            .map(Permission::getPermissionRoleName)
+            .min(Long::compareTo)
+            .orElseThrow(IllegalArgumentException::new);
+
+        /* 조회된 권한들의 scheduleId 리스트화 (중복 제거) */
+        List<Long> scheduleIdList = permissionList.stream()
+            .map(Permission::getPermissionScheduleId)
+            .distinct()
+            .toList();
+
+        return RoleAndSchedulesDTO.builder()
+            .roleName(roleName)
+            .scheduleIdList(scheduleIdList)
+            .build();
+
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
@@ -329,7 +329,7 @@ public class ScheduleController {
 
     /* 일정 시트에 사용될 데이터 수집 */
     @GetMapping("/sheet/{projectId}")
-    public ResponseEntity<ResponseMessage> getSheetData(@PathVariable Long projectId, @RequestBody String employeeId){
+    public ResponseEntity<ResponseMessage> getSheetData(@PathVariable Long projectId, @RequestHeader String employeeId){
 
         HttpHeaders headers = HttpHeadersCreator.createHeaders();
 

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
@@ -20,6 +20,7 @@ import org.omoknoone.ppm.domain.schedule.dto.SearchScheduleListDTO;
 import org.omoknoone.ppm.domain.schedule.service.ScheduleService;
 import org.omoknoone.ppm.domain.schedule.vo.RequestSchedule;
 import org.omoknoone.ppm.domain.schedule.vo.ResponseSchedule;
+import org.omoknoone.ppm.domain.schedule.vo.ResponseScheduleSheetData;
 import org.omoknoone.ppm.domain.schedule.vo.ResponseSearchScheduleList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -323,5 +325,22 @@ public class ScheduleController {
             .ok()
             .headers(headers)
             .body(new ResponseMessage(200, "일정을 10등분 후 각각의 예상 비율 계산", responseMap));
+    }
+
+    /* 일정 시트에 사용될 데이터 수집 */
+    @GetMapping("/sheet/{projectId}")
+    public ResponseEntity<ResponseMessage> getSheetData(@PathVariable Long projectId, @RequestBody String employeeId){
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
+        List<ResponseScheduleSheetData> sheetDataList = scheduleService.getSheetData(projectId, employeeId);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("SheetData", sheetDataList);
+
+        return ResponseEntity
+            .ok()
+            .headers(headers)
+            .body(new ResponseMessage(200, "시트에 삽입될 데이터 조회 완료", responseMap));
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/dto/ScheduleSheetDataDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/dto/ScheduleSheetDataDTO.java
@@ -1,0 +1,33 @@
+package org.omoknoone.ppm.domain.schedule.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class ScheduleSheetDataDTO {
+    private Long scheduleId;
+    private String scheduleTitle;
+    private LocalDate scheduleStartDate;
+    private LocalDate scheduleEndDate;
+    private Integer scheduleDepth;
+    private Integer schedulePriority;
+    private Integer scheduleProgress;
+    private Long scheduleStatus;
+    private Integer scheduleManHours;
+    private Long scheduleParentScheduleId;
+    private Long schedulePrecedingScheduleId;
+    private List<StakeholdersEmployeeInfoDTO> scheduleEmployeeInfoList;
+    private List<ScheduleSheetDataDTO> scheduleChildScheduleList;
+}

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/dto/ScheduleSheetDataDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/dto/ScheduleSheetDataDTO.java
@@ -29,5 +29,5 @@ public class ScheduleSheetDataDTO {
     private Long scheduleParentScheduleId;
     private Long schedulePrecedingScheduleId;
     private List<StakeholdersEmployeeInfoDTO> scheduleEmployeeInfoList;
-    private List<ScheduleSheetDataDTO> scheduleChildScheduleList;
+    private List<ScheduleSheetDataDTO> __children;
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
@@ -12,6 +12,7 @@ import org.omoknoone.ppm.domain.schedule.dto.ModifyScheduleTitleAndContentDTO;
 import org.omoknoone.ppm.domain.schedule.dto.RequestModifyScheduleDTO;
 import org.omoknoone.ppm.domain.schedule.dto.ScheduleDTO;
 import org.omoknoone.ppm.domain.schedule.dto.SearchScheduleListDTO;
+import org.omoknoone.ppm.domain.schedule.vo.ResponseScheduleSheetData;
 
 public interface ScheduleService {
 
@@ -79,4 +80,7 @@ public interface ScheduleService {
 
     /* 구간별 일정 예상 누적 진행률 */
     int[] calculateScheduleRatios(LocalDate startDate, LocalDate endDate);
+
+    /* 일정 시트에 사용될 데이터 수집 */
+    List<ResponseScheduleSheetData> getSheetData(Long projectId, String employeeId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
@@ -474,10 +474,10 @@ public class ScheduleServiceImpl implements ScheduleService {
             if (dto.getScheduleParentScheduleId() != null) {
                 for (ScheduleSheetDataDTO parentDto : scheduleSheetDataDTOList) {
                     if (parentDto.getScheduleId().equals(dto.getScheduleParentScheduleId())) {
-                        if (parentDto.getScheduleChildScheduleList() == null) {
-                            parentDto.setScheduleChildScheduleList(new ArrayList<>());
+                        if (parentDto.get__children() == null) {
+                            parentDto.set__children(new ArrayList<>());
                         }
-                        parentDto.getScheduleChildScheduleList().add(dto);
+                        parentDto.get__children().add(dto);
                         iterator.remove();
                         break;
                     }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/vo/ResponseScheduleSheetData.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/vo/ResponseScheduleSheetData.java
@@ -28,5 +28,5 @@ public class ResponseScheduleSheetData {
     private Long scheduleParentScheduleId;
     private Long schedulePrecedingScheduleId;
     private List<StakeholdersEmployeeInfoDTO> scheduleEmployeeInfoList;
-    private List<ResponseScheduleSheetData> scheduleChildScheduleList;
+    private List<ResponseScheduleSheetData> __children;
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/vo/ResponseScheduleSheetData.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/vo/ResponseScheduleSheetData.java
@@ -1,0 +1,32 @@
+package org.omoknoone.ppm.domain.schedule.vo;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString
+public class ResponseScheduleSheetData {
+    private Long scheduleId;
+    private String scheduleTitle;
+    private LocalDate scheduleStartDate;
+    private LocalDate scheduleEndDate;
+    private Integer scheduleDepth;
+    private Integer schedulePriority;
+    private Integer scheduleProgress;
+    private Long scheduleStatus;
+    private Integer scheduleManHours;
+    private Long scheduleParentScheduleId;
+    private Long schedulePrecedingScheduleId;
+    private List<StakeholdersEmployeeInfoDTO> scheduleEmployeeInfoList;
+    private List<ResponseScheduleSheetData> scheduleChildScheduleList;
+}

--- a/src/main/java/org/omoknoone/ppm/domain/stakeholders/dto/StakeholdersEmployeeInfoDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/stakeholders/dto/StakeholdersEmployeeInfoDTO.java
@@ -1,0 +1,34 @@
+package org.omoknoone.ppm.domain.stakeholders.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class StakeholdersEmployeeInfoDTO {
+    Long stakeholdersId;
+    Long stakeholdersType;
+    Long stakeholdersScheduleId;
+    Long ProjectMemberId;
+    String employeeId;
+    String employeeName;
+
+    @Builder
+    public StakeholdersEmployeeInfoDTO(Long stakeholdersId, Long stakeholdersType, Long stakeholdersScheduleId,
+        Long projectMemberId, String employeeId, String employeeName) {
+        this.stakeholdersId = stakeholdersId;
+        this.stakeholdersType = stakeholdersType;
+        this.stakeholdersScheduleId = stakeholdersScheduleId;
+        ProjectMemberId = projectMemberId;
+        this.employeeId = employeeId;
+        this.employeeName = employeeName;
+    }
+}

--- a/src/main/java/org/omoknoone/ppm/domain/stakeholders/repository/StakeholdersRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/stakeholders/repository/StakeholdersRepository.java
@@ -1,11 +1,23 @@
 package org.omoknoone.ppm.domain.stakeholders.repository;
 
 import org.omoknoone.ppm.domain.stakeholders.aggregate.Stakeholders;
+import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface StakeholdersRepository extends JpaRepository<Stakeholders, Long> {
 
     List<Stakeholders> findStakeholdersByStakeholdersScheduleId(Long scheduleId);
+
+
+    @Query("SELECT new org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO("
+        + " st.stakeholdersId, st.stakeholdersType, st.stakeholdersScheduleId, "
+        + " st.stakeholdersProjectMemberId, e.employeeId, e.employeeName) "
+        + "FROM Stakeholders st "
+        + "JOIN ProjectMember p ON st.stakeholdersProjectMemberId = p.projectMemberId "
+        + "JOIN Employee e ON p.projectMemberEmployeeId = e.employeeId "
+        + "WHERE st.stakeholdersScheduleId IN :scheduleIdList")
+    List<StakeholdersEmployeeInfoDTO> findStakeholdersEmployeeInfoByScheduleIdList(Long[] scheduleIdList);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/stakeholders/service/StakeholdersService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/stakeholders/service/StakeholdersService.java
@@ -4,6 +4,7 @@ import org.omoknoone.ppm.domain.stakeholders.aggregate.Stakeholders;
 import org.omoknoone.ppm.domain.stakeholders.dto.CreateStakeholdersDTO;
 import org.omoknoone.ppm.domain.stakeholders.dto.ModifyStakeholdersDTO;
 import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersDTO;
+import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO;
 
 import java.util.List;
 
@@ -16,4 +17,6 @@ public interface StakeholdersService {
     Long modifyStakeholder(ModifyStakeholdersDTO modifyStakeholdersDTO);
 
     Long removeStakeholder(Long stakeholdersId);
+
+    List<StakeholdersEmployeeInfoDTO> viewStakeholdersEmployeeInfo(Long[] scheduleIdList);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/stakeholders/service/StakeholdersServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/stakeholders/service/StakeholdersServiceImpl.java
@@ -9,6 +9,7 @@ import org.omoknoone.ppm.domain.stakeholders.aggregate.Stakeholders;
 import org.omoknoone.ppm.domain.stakeholders.dto.CreateStakeholdersDTO;
 import org.omoknoone.ppm.domain.stakeholders.dto.ModifyStakeholdersDTO;
 import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersDTO;
+import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO;
 import org.omoknoone.ppm.domain.stakeholders.repository.StakeholdersRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -79,5 +80,12 @@ public class StakeholdersServiceImpl implements StakeholdersService {
         stakeholdersRepository.save(stakeholders);
 
         return stakeholders.getStakeholdersId();
+    }
+
+    @Override
+    public List<StakeholdersEmployeeInfoDTO> viewStakeholdersEmployeeInfo(Long[] scheduleIdList) {
+
+
+        return stakeholdersRepository.findStakeholdersEmployeeInfoByScheduleIdList(scheduleIdList);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Front Schedule Sheet에 사용할 일정 조회 기능
  - 후손 트리 구조로 반환하는 기능
  - PM, PL, PA 에 따라 일정이 조회되는 범위가 다른 기능


### 📷스크린샷 (선택)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
