### PR TITLE
[PR] 프로젝트 구성원 추가 그리고 제외 및 내역 관리 기능 개선

### DIFF
--- a/src/main/java/org/omoknoone/ppm/domain/employee/dto/ViewEmployeeResponseDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/employee/dto/ViewEmployeeResponseDTO.java
@@ -18,9 +18,12 @@ public class ViewEmployeeResponseDTO {
     private String employeeContact;
     private String employeeCompanyName;
     private Boolean employeeIsExternalPartner;
+    private LocalDateTime employeeCreatedDate;
 
     @Builder
-    public ViewEmployeeResponseDTO(String employeeId, String employeeName, String employeeEmail, String employeeDepartment, String employeeContact, String employeeCompanyName, Boolean employeeIsExternalPartner) {
+    public ViewEmployeeResponseDTO(String employeeId, String employeeName, String employeeEmail, String employeeDepartment,
+                                String employeeContact, String employeeCompanyName,
+                                Boolean employeeIsExternalPartner, LocalDateTime employeeCreatedDate) {
         this.employeeId = employeeId;
         this.employeeName = employeeName;
         this.employeeEmail = employeeEmail;
@@ -28,6 +31,7 @@ public class ViewEmployeeResponseDTO {
         this.employeeContact = employeeContact;
         this.employeeCompanyName = employeeCompanyName;
         this.employeeIsExternalPartner = employeeIsExternalPartner;
+        this.employeeCreatedDate = employeeCreatedDate;
     }
 
     public ViewEmployeeResponseDTO(Employee employee) {

--- a/src/main/java/org/omoknoone/ppm/domain/employee/repository/EmployeeRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/employee/repository/EmployeeRepository.java
@@ -3,6 +3,9 @@ package org.omoknoone.ppm.domain.employee.repository;
 import org.omoknoone.ppm.domain.employee.aggregate.Employee;
 import org.omoknoone.ppm.domain.employee.dto.ViewEmployeeResponseDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface EmployeeRepository extends JpaRepository<Employee, String> {
 
@@ -11,4 +14,23 @@ public interface EmployeeRepository extends JpaRepository<Employee, String> {
 	Employee searchEmployeeByEmployeeName(String employeeName);
 
 	Employee findByEmployeeId(String projectMemberEmployeeId);
+
+	@Query("SELECT " +
+			"e " +
+			" FROM Employee e " +
+			" WHERE e.employeeId" +
+			" NOT IN (SELECT pm.projectMemberEmployeeId" +
+			" FROM ProjectMember pm" +
+			" WHERE pm.projectMemberProjectId = :projectId AND pm.projectMemberIsExcluded = false)")
+	List<Employee> findAvailableMembers(Integer projectId);
+
+	@Query("SELECT " +
+			"e " +
+			"FROM Employee e " +
+			"WHERE e.employeeId" +
+			" NOT IN (SELECT pm.projectMemberEmployeeId" +
+			" FROM ProjectMember pm" +
+			" WHERE pm.projectMemberProjectId = :projectId AND pm.projectMemberIsExcluded = false)" +
+			" AND (e.employeeName LIKE %:query% OR e.employeeEmail LIKE %:query%)")
+	List<Employee> findAvailableMembersByQuery(Integer projectId, String query);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/employee/service/EmployeeService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/employee/service/EmployeeService.java
@@ -1,6 +1,5 @@
 package org.omoknoone.ppm.domain.employee.service;
 
-import org.omoknoone.ppm.domain.employee.aggregate.Employee;
 import org.omoknoone.ppm.domain.employee.dto.LoginEmployeeDTO;
 import org.omoknoone.ppm.domain.employee.dto.ModifyEmployeeRequestDTO;
 import org.omoknoone.ppm.domain.employee.dto.SignUpEmployeeRequestDTO;
@@ -8,6 +7,8 @@ import org.omoknoone.ppm.domain.employee.dto.ViewEmployeeResponseDTO;
 import org.omoknoone.ppm.domain.employee.dto.*;
 
 import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.util.List;
 
 public interface EmployeeService extends UserDetailsService{
 
@@ -25,4 +26,8 @@ public interface EmployeeService extends UserDetailsService{
     String modifyPassword(ModifyPasswordRequestDTO modifyPasswordRequestDTO);
 
 //	String getEmployeeNameByProjectMemberId(String projectMemberId);
+
+    List<ViewEmployeeResponseDTO> viewAvailableMembers(Integer projectId);
+
+    List<ViewEmployeeResponseDTO> viewAndSearchAvailableMembersByQuery(Integer projectIdn, String query);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/employee/service/EmployeeServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/employee/service/EmployeeServiceImpl.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -106,6 +108,25 @@ public class EmployeeServiceImpl implements EmployeeService{
         Employee employee = employeeRepository.searchEmployeeByEmployeeName(employeeName);
         return new ViewEmployeeResponseDTO(employee);
     }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ViewEmployeeResponseDTO> viewAvailableMembers(Integer projectId) {
+        return employeeRepository.findAvailableMembers(projectId)
+                .stream()
+                .map(employee -> modelMapper.map(employee, ViewEmployeeResponseDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ViewEmployeeResponseDTO> viewAndSearchAvailableMembersByQuery(Integer projectId, String query) {
+        return employeeRepository.findAvailableMembersByQuery(projectId, query)
+                .stream()
+                .map(employee -> modelMapper.map(employee, ViewEmployeeResponseDTO.class))
+                .collect(Collectors.toList());
+    }
+
 
     /* 메소드가 옳지 않고 사용 되는 곳이 없음 */
 //    @Override

--- a/src/main/java/org/omoknoone/ppm/domain/projectDashboard/service/GraphServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectDashboard/service/GraphServiceImpl.java
@@ -17,7 +17,7 @@ import org.omoknoone.ppm.domain.project.service.ProjectService;
 import org.omoknoone.ppm.domain.projectDashboard.aggregate.Graph;
 import org.omoknoone.ppm.domain.projectDashboard.dto.GraphDTO;
 import org.omoknoone.ppm.domain.projectDashboard.repository.GraphRepository;
-import org.omoknoone.ppm.domain.projectmember.dto.viewProjectMembersByProjectResponseDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO;
 import org.omoknoone.ppm.domain.projectmember.service.ProjectMemberService;
 import org.omoknoone.ppm.domain.schedule.service.ScheduleService;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -142,11 +142,11 @@ public class GraphServiceImpl implements GraphService {
         // 구성원 목록 (이름)
 
 
-        List<viewProjectMembersByProjectResponseDTO> dtoList =
+        List<ViewProjectMembersByProjectResponseDTO> dtoList =
             projectMemberService.viewProjectMembersByProject(Integer.valueOf(projectId));
 
         // categories에 구성원 이름 담기
-        for (viewProjectMembersByProjectResponseDTO dto : dtoList) {
+        for (ViewProjectMembersByProjectResponseDTO dto : dtoList) {
             // String name = employeeService.getEmployeeNameByProjectMemberId(String.valueOf(dto.getProjectMemberId()));
             // columnCategories.add(name);
             count += 1;

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
@@ -58,21 +58,13 @@ public class ProjectMember {
         this.projectMemberModifiedDate = projectMemberModifiedDate;
     }
 
-    public void modify(ModifyProjectMemberRequestDTO dto) {
-//        this.projectMemberRoleId = dto.getProjectMemberRoleId();
-        this.projectMemberModifiedDate = LocalDateTime.now();
-    }
-
     public void remove() {
         this.projectMemberIsExcluded = true;
         this.projectMemberExclusionDate = LocalDateTime.now();
     }
 
-    public void reactivate() {
-        if (!this.projectMemberIsExcluded) {
-            throw new IllegalStateException("이미 활성화된 구성원입니다. 다시 활성화할 수 없습니다.");
-        }
+    public void include() {
         this.projectMemberIsExcluded = false;
-        this.projectMemberExclusionDate = null;
+        this.projectMemberModifiedDate = LocalDateTime.now();
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @ToString

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMember.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
-import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
-import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,7 +24,7 @@ public class ProjectMember {
 
     @CreationTimestamp
     @Column(name = "project_member_created_date", nullable = false, length = 30)
-    private LocalDate projectMemberCreatedDate;
+    private LocalDateTime projectMemberCreatedDate;
 
     @Column(name = "project_member_modified_date", length = 30)
     private LocalDateTime projectMemberModifiedDate;
@@ -46,7 +44,7 @@ public class ProjectMember {
     @Builder
     public ProjectMember(Integer projectMemberId, Integer projectMemberProjectId,
                          String projectMemberEmployeeId, Boolean projectMemberIsExcluded,
-                         LocalDateTime projectMemberExclusionDate, LocalDate projectMemberCreatedDate,
+                         LocalDateTime projectMemberExclusionDate, LocalDateTime projectMemberCreatedDate,
                          LocalDateTime projectMemberModifiedDate) {
         this.projectMemberId = projectMemberId;
         this.projectMemberProjectId = projectMemberProjectId;

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMemberHistory.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMemberHistory.java
@@ -23,24 +23,23 @@ public class ProjectMemberHistory {
     @Column(name = "project_member_history_reason", nullable = false)
     private String projectMemberHistoryReason;
 
-    @UpdateTimestamp
-    @Column(name = "project_member_history_modified_date", nullable = false, length = 30)
-    private LocalDateTime projectMemberHistoryModifiedDate;
+    @Column(name = "project_member_created_date", nullable = false)
+    private LocalDateTime projectMemberCreatedDate;
 
-    @Column(name = "project_member_history_is_deleted", nullable = false)
-    private Boolean projectMemberHistoryIsDeleted = false;
+    @Column(name = "project_member_exclusion_date")
+    private LocalDateTime projectMemberExclusionDate;
 
-    @Column(name = "project_member_history_deleted_date", length = 30)
-    private String projectMemberHistoryDeletedDate;
-
-    @Column(name = "project_member_history_project_member_id", nullable = false)
+    @JoinColumn(name = "project_member_id", nullable = false)
     private Integer projectMemberHistoryProjectMemberId;
 
     @Builder
-
-    public ProjectMemberHistory(String projectMemberHistoryReason, Boolean projectMemberHistoryIsDeleted, Integer projectMemberHistoryProjectMemberId) {
+    public ProjectMemberHistory(Long projectMemberHistoryId, String projectMemberHistoryReason,
+                                LocalDateTime projectMemberCreatedDate, LocalDateTime projectMemberExclusionDate,
+                                Integer projectMemberHistoryProjectMemberId) {
+        this.projectMemberHistoryId = projectMemberHistoryId;
         this.projectMemberHistoryReason = projectMemberHistoryReason;
-        this.projectMemberHistoryIsDeleted = projectMemberHistoryIsDeleted;
+        this.projectMemberCreatedDate = projectMemberCreatedDate;
+        this.projectMemberExclusionDate = projectMemberExclusionDate;
         this.projectMemberHistoryProjectMemberId = projectMemberHistoryProjectMemberId;
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMemberHistory.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/aggregate/ProjectMemberHistory.java
@@ -4,8 +4,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
@@ -46,7 +46,7 @@ public class ProjectMemberController {
 
     @GetMapping("/available/{projectId}")
     public ResponseEntity<ResponseMessage> viewAndSearchAvailableMembers(@PathVariable("projectId") Integer projectId,
-                                                                        @RequestParam(value = "query", required = false) String query) {
+                                                                         @RequestParam(value = "query", required = false) String query) {
 
         HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
@@ -85,10 +85,8 @@ public class ProjectMemberController {
 
         HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
-        requestDTO.setProjectMemberId(projectMemberId);
-
         try {
-            projectMemberService.removeProjectMember(requestDTO);
+            projectMemberService.removeProjectMember(projectMemberId, requestDTO.getProjectMemberHistoryReason());
             Map<String, Object> responseMap = new HashMap<>();
             responseMap.put("removeProjectMember", projectMemberId);
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
@@ -7,6 +7,7 @@ import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewAvailableMembersResponseDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO;
 import org.omoknoone.ppm.domain.projectmember.service.ProjectMemberService;
 import org.springframework.http.HttpHeaders;
@@ -41,6 +42,24 @@ public class ProjectMemberController {
                 .ok()
                 .headers(headers)
                 .body(new ResponseMessage(200, "프로젝트 구성원 조회 성공", responseMap));
+    }
+
+    @GetMapping("/available/{projectId}")
+    public ResponseEntity<ResponseMessage> viewAndSearchAvailableMembers(@PathVariable("projectId") Integer projectId,
+                                                                        @RequestParam(value = "query", required = false) String query) {
+
+        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+
+        List<ViewAvailableMembersResponseDTO> responseDTOs
+                = projectMemberService.viewAndSearchAvailableMembers(projectId, query);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("viewAvailableMembers", responseDTOs);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "프로젝트에 합류할 수 있는 구성원 조회 성공", responseMap));
     }
 
     @PostMapping("/create")
@@ -84,55 +103,55 @@ public class ProjectMemberController {
         }
     }
 
-    @PutMapping("/reactivate/{projectMemberId}")
-    public ResponseEntity<ResponseMessage> reactivateProjectMember(
-            @PathVariable Integer projectMemberId,
-            @RequestBody ModifyProjectMemberRequestDTO requestDTO) {
+//    @PutMapping("/reactivate/{projectMemberId}")
+//    public ResponseEntity<ResponseMessage> reactivateProjectMember(
+//            @PathVariable Integer projectMemberId,
+//            @RequestBody ModifyProjectMemberRequestDTO requestDTO) {
+//
+//        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+//
+//        requestDTO.setProjectMemberId(projectMemberId);
+//
+//        try {
+//            projectMemberService.reactivateProjectMember(requestDTO);
+//            Map<String, Object> responseMap = new HashMap<>();
+//            responseMap.put("reactivateProjectMember", projectMemberId);
+//
+//            return ResponseEntity
+//                    .ok()
+//                    .headers(headers)
+//                    .body(new ResponseMessage(200, "구성원 활성화가 완료.", responseMap));
+//        } catch (EntityNotFoundException ex) {
+//            return ResponseEntity
+//                    .status(HttpStatus.NOT_FOUND)
+//                    .body(new ResponseMessage(404, "구성원을 찾을 수 없음."));
+//        } catch (IllegalStateException ex) {
+//            return ResponseEntity
+//                    .status(HttpStatus.BAD_REQUEST)
+//                    .body(new ResponseMessage(400, "이미 활성화된 구성원입니다. 다시 활성화할 수 없습니다."));
+//        }
+//    }
 
-        HttpHeaders headers = HttpHeadersCreator.createHeaders();
-
-        requestDTO.setProjectMemberId(projectMemberId);
-
-        try {
-            projectMemberService.reactivateProjectMember(requestDTO);
-            Map<String, Object> responseMap = new HashMap<>();
-            responseMap.put("reactivateProjectMember", projectMemberId);
-
-            return ResponseEntity
-                    .ok()
-                    .headers(headers)
-                    .body(new ResponseMessage(200, "구성원 활성화가 완료.", responseMap));
-        } catch (EntityNotFoundException ex) {
-            return ResponseEntity
-                    .status(HttpStatus.NOT_FOUND)
-                    .body(new ResponseMessage(404, "구성원을 찾을 수 없음."));
-        } catch (IllegalStateException ex) {
-            return ResponseEntity
-                    .status(HttpStatus.BAD_REQUEST)
-                    .body(new ResponseMessage(400, "이미 활성화된 구성원입니다. 다시 활성화할 수 없습니다."));
-        }
-    }
-
-    @PutMapping("/modify/{projectMemberId}")
-    public ResponseEntity<ResponseMessage> modifyProjectMember(@RequestBody ModifyProjectMemberRequestDTO requestDTO) {
-
-        HttpHeaders headers = HttpHeadersCreator.createHeaders();
-
-        try {
-            Integer projectMemberId = projectMemberService.modifyProjectMember(requestDTO);
-
-            Map<String, Object> responseMap = new HashMap<>();
-            responseMap.put("modifyProjectMember", projectMemberId);
-
-            return ResponseEntity
-                    .ok()
-                    .headers(headers)
-                    .body(new ResponseMessage(200, "구성원의 권한 수정이 완료.", responseMap));
-        } catch (EntityNotFoundException ex) {
-            return ResponseEntity
-                    .status(HttpStatus.NOT_FOUND)
-                    .body(new ResponseMessage(404, "구성원을 찾을 수 없음."));
-        }
-    }
+//    @PutMapping("/modify/{projectMemberId}")
+//    public ResponseEntity<ResponseMessage> modifyProjectMember(@RequestBody ModifyProjectMemberRequestDTO requestDTO) {
+//
+//        HttpHeaders headers = HttpHeadersCreator.createHeaders();
+//
+//        try {
+//            Integer projectMemberId = projectMemberService.modifyProjectMember(requestDTO);
+//
+//            Map<String, Object> responseMap = new HashMap<>();
+//            responseMap.put("modifyProjectMember", projectMemberId);
+//
+//            return ResponseEntity
+//                    .ok()
+//                    .headers(headers)
+//                    .body(new ResponseMessage(200, "구성원의 권한 수정이 완료.", responseMap));
+//        } catch (EntityNotFoundException ex) {
+//            return ResponseEntity
+//                    .status(HttpStatus.NOT_FOUND)
+//                    .body(new ResponseMessage(404, "구성원을 찾을 수 없음."));
+//        }
+//    }
 
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/controller/ProjectMemberController.java
@@ -5,18 +5,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
-import org.omoknoone.ppm.common.annotation.Permission;
 import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
-import org.omoknoone.ppm.domain.projectmember.dto.viewProjectMembersByProjectResponseDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO;
 import org.omoknoone.ppm.domain.projectmember.service.ProjectMemberService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +31,7 @@ public class ProjectMemberController {
 
         HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
-        List<viewProjectMembersByProjectResponseDTO> responseDTOs
+        List<ViewProjectMembersByProjectResponseDTO> responseDTOs
                 = projectMemberService.viewProjectMembersByProject(projectId);
 
         Map<String, Object> responseMap = new HashMap<>();

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/CreateProjectMemberHistoryRequestDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/CreateProjectMemberHistoryRequestDTO.java
@@ -1,0 +1,26 @@
+package org.omoknoone.ppm.domain.projectmember.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter @Setter
+public class CreateProjectMemberHistoryRequestDTO {
+
+    private final Integer projectMemberHistoryProjectMemberId; // Final 필드로 설정하여 setter를 자동으로 차단
+
+    private String projectMemberHistoryReason;
+    private LocalDateTime projectMemberCreatedDate;
+    private LocalDateTime projectMemberExclusionDate;
+
+    @Builder
+    public CreateProjectMemberHistoryRequestDTO(Integer projectMemberHistoryProjectMemberId,
+                                                String projectMemberHistoryReason, LocalDateTime projectMemberCreatedDate,
+                                                LocalDateTime projectMemberExclusionDate) {
+        this.projectMemberHistoryProjectMemberId = projectMemberHistoryProjectMemberId;
+        this.projectMemberHistoryReason = projectMemberHistoryReason;
+        this.projectMemberCreatedDate = projectMemberCreatedDate;
+        this.projectMemberExclusionDate = projectMemberExclusionDate;
+    }
+}

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/CreateProjectMemberRequestDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/CreateProjectMemberRequestDTO.java
@@ -13,7 +13,8 @@ public class CreateProjectMemberRequestDTO {
     private Long permissionScheduleId;
 
     @Builder
-    public CreateProjectMemberRequestDTO(Integer projectMemberProjectId, Integer projectMemberRoleId, String projectMemberEmployeeId, Long permissionScheduleId) {
+    public CreateProjectMemberRequestDTO(Integer projectMemberProjectId, Integer projectMemberRoleId,
+                                         String projectMemberEmployeeId, Long permissionScheduleId) {
         this.projectMemberProjectId = projectMemberProjectId;
         this.projectMemberRoleId = projectMemberRoleId;
         this.projectMemberEmployeeId = projectMemberEmployeeId;

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ModifyProjectMemberRequestDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ModifyProjectMemberRequestDTO.java
@@ -2,16 +2,12 @@ package org.omoknoone.ppm.domain.projectmember.dto;
 
 import lombok.*;
 
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter
+@Getter @Setter
 public class ModifyProjectMemberRequestDTO {
 
-    @Setter
-    private Integer projectMemberId;
-
-    @Setter
-    private Integer projectMemberRoleId;
-
     private String projectMemberHistoryReason;
+
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewAvailableMemberResponseDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewAvailableMemberResponseDTO.java
@@ -1,0 +1,4 @@
+package org.omoknoone.ppm.domain.projectmember.dto;
+
+public class ViewAvailableMemberResponseDTO {
+}

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewAvailableMemberResponseDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewAvailableMemberResponseDTO.java
@@ -1,4 +1,0 @@
-package org.omoknoone.ppm.domain.projectmember.dto;
-
-public class ViewAvailableMemberResponseDTO {
-}

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewAvailableMembersResponseDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewAvailableMembersResponseDTO.java
@@ -3,20 +3,18 @@ package org.omoknoone.ppm.domain.projectmember.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class ViewProjectMembersByProjectResponseDTO {
+public class ViewAvailableMembersResponseDTO {
 
     private String employeeName;
-    private Integer projectMemberRoleId;
     private String employeeEmail;
     private String employeeContact;
-    private LocalDateTime projectMemberCreatedDate;
+    private LocalDateTime employeeCreatedDate;
 }
-
-
-

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewProjectMembersByProjectResponseDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewProjectMembersByProjectResponseDTO.java
@@ -1,22 +1,27 @@
 package org.omoknoone.ppm.domain.projectmember.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
+@ToString
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 public class ViewProjectMembersByProjectResponseDTO {
 
     private String employeeName;
-    private Integer projectMemberRoleId;
+    private Long projectMemberRoleName;
     private String employeeEmail;
     private String employeeContact;
     private LocalDateTime projectMemberCreatedDate;
+
+    @Builder
+    public ViewProjectMembersByProjectResponseDTO(String employeeName, Long projectMemberRoleName,
+                                                String employeeEmail, String employeeContact, LocalDateTime projectMemberCreatedDate) {
+        this.employeeName = employeeName;
+        this.projectMemberRoleName = projectMemberRoleName;
+        this.employeeEmail = employeeEmail;
+        this.employeeContact = employeeContact;
+        this.projectMemberCreatedDate = projectMemberCreatedDate;
+    }
 }
-
-
-

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewProjectMembersByProjectResponseDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/dto/ViewProjectMembersByProjectResponseDTO.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class viewProjectMembersByProjectResponseDTO {
+public class ViewProjectMembersByProjectResponseDTO {
 
     private Integer projectMemberId;
     private Integer projectMemberProjectId;

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberHistoryRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberHistoryRepository.java
@@ -3,5 +3,8 @@ package org.omoknoone.ppm.domain.projectmember.repository;
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMemberHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProjectMemberHistoryRepository extends JpaRepository<ProjectMemberHistory, Long> {
+    List<ProjectMemberHistory> findByProjectMemberHistoryProjectMemberId(Integer projectMemberId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberRepository.java
@@ -15,4 +15,5 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, In
     ProjectMember findByProjectMemberEmployeeIdAndProjectMemberProjectId(String employeeId, Integer projectId);
 
     List<ProjectMember> findByProjectMemberEmployeeId(String employeeId);
+
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberRepository.java
@@ -1,6 +1,7 @@
 package org.omoknoone.ppm.domain.projectmember.repository;
 
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMember;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,8 +10,13 @@ import java.util.List;
 
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Integer> {
 
-    @Query("SELECT pm FROM ProjectMember pm WHERE pm.projectMemberProjectId = :projectId")
-    List<ProjectMember> findByProjectMemberProjectId(@Param("projectId") Integer projectId);
+    @Query("SELECT new org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO(e.employeeName, " +
+            "p.permissionRoleName, e.employeeEmail, e.employeeContact, pm.projectMemberCreatedDate) " +
+            "FROM ProjectMember pm " +
+            "JOIN Employee e ON pm.projectMemberEmployeeId = e.employeeId " +
+            "LEFT JOIN Permission p ON p.permissionProjectMemberId = pm.projectMemberId " +
+            "WHERE pm.projectMemberProjectId = :projectId")
+    List<ViewProjectMembersByProjectResponseDTO> findByProjectMembersProjectId(@Param("projectId") Integer projectId);
 
     ProjectMember findByProjectMemberEmployeeIdAndProjectMemberProjectId(String employeeId, Integer projectId);
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberHistoryService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberHistoryService.java
@@ -1,7 +1,12 @@
 package org.omoknoone.ppm.domain.projectmember.service;
 
-import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
+import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMemberHistory;
+import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberHistoryRequestDTO;
+
+import java.util.List;
 
 public interface ProjectMemberHistoryService {
-    void createProjectMemberHistory(ModifyProjectMemberRequestDTO projectMemberRequestDTO);
-}
+
+    void createProjectMemberHistory(CreateProjectMemberHistoryRequestDTO requestDTO);
+
+    List<ProjectMemberHistory> viewProjectMemberHistory(Integer projectMemberId);}

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberHistoryServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberHistoryServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Service
 public class ProjectMemberHistoryServiceImpl implements ProjectMemberHistoryService{
 
-    private ProjectMemberHistoryRepository projectMemberHistoryRepository;
+    private final ProjectMemberHistoryRepository projectMemberHistoryRepository;
 
     @Transactional
     @Override

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberHistoryServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberHistoryServiceImpl.java
@@ -2,26 +2,34 @@ package org.omoknoone.ppm.domain.projectmember.service;
 
 import lombok.RequiredArgsConstructor;
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMemberHistory;
-import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberHistoryRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.repository.ProjectMemberHistoryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class ProjectMemberHistoryServiceImpl implements ProjectMemberHistoryService{
 
-    private final ProjectMemberHistoryRepository projectMemberHistoryRepository;
+    private ProjectMemberHistoryRepository projectMemberHistoryRepository;
 
     @Transactional
     @Override
-    public void createProjectMemberHistory(ModifyProjectMemberRequestDTO projectMemberRequestDTO) {
-        ProjectMemberHistory projectMemberHistory = ProjectMemberHistory
-                .builder()
-                .projectMemberHistoryProjectMemberId(projectMemberRequestDTO.getProjectMemberId())
-                .projectMemberHistoryReason(projectMemberRequestDTO.getProjectMemberHistoryReason())
+    public void createProjectMemberHistory(CreateProjectMemberHistoryRequestDTO requestDTO) {
+        ProjectMemberHistory history = ProjectMemberHistory.builder()
+                .projectMemberHistoryProjectMemberId(requestDTO.getProjectMemberHistoryProjectMemberId())
+                .projectMemberHistoryReason(requestDTO.getProjectMemberHistoryReason())
+                .projectMemberCreatedDate(requestDTO.getProjectMemberCreatedDate())
+                .projectMemberExclusionDate(requestDTO.getProjectMemberExclusionDate())
                 .build();
+        projectMemberHistoryRepository.save(history);
+    }
 
-        projectMemberHistoryRepository.save(projectMemberHistory);
+    @Transactional(readOnly = true)
+    @Override
+    public List<ProjectMemberHistory> viewProjectMemberHistory(Integer projectMemberId) {
+        return projectMemberHistoryRepository.findByProjectMemberHistoryProjectMemberId(projectMemberId);
     }
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
@@ -2,7 +2,6 @@ package org.omoknoone.ppm.domain.projectmember.service;
 
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMember;
 import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
-import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ViewAvailableMembersResponseDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO;
 
@@ -16,13 +15,13 @@ public interface ProjectMemberService {
 
     Integer createProjectMember(CreateProjectMemberRequestDTO createProjectMemberRequestDTO);
 
-    void removeProjectMember(ModifyProjectMemberRequestDTO projectMemberId);
+    void removeProjectMember(Integer projectMemberId, String projectMemberHistoryReason);
 
 //    void reactivateProjectMember(ModifyProjectMemberRequestDTO projectMemberId);
 
 //    Integer modifyProjectMember(ModifyProjectMemberRequestDTO modifyProjectMemberRequestDTO);
 
-//    Integer viewProjectMemberId(String employeeId, Integer projectId);
+    Integer viewProjectMemberId(String employeeId, Integer projectId);
 
-//    List<ProjectMember> viewProjectMemberListByEmployeeId(String employeeId);
+    List<ProjectMember> viewProjectMemberListByEmployeeId(String employeeId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
@@ -3,12 +3,16 @@ package org.omoknoone.ppm.domain.projectmember.service;
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMember;
 import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
-import org.omoknoone.ppm.domain.projectmember.dto.viewProjectMembersByProjectResponseDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewAvailableMemberResponseDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO;
 
 import java.util.List;
 
 public interface ProjectMemberService {
-    List<viewProjectMembersByProjectResponseDTO> viewProjectMembersByProject(Integer projectMemberProjectId);
+
+    List<ViewProjectMembersByProjectResponseDTO> viewProjectMembersByProject(Integer projectMemberProjectId);
+
+    List<ViewAvailableMemberResponseDTO> viewAndSearchAvailableMembers(Integer projectMemberProjectId, String query);
 
     Integer createProjectMember(CreateProjectMemberRequestDTO createProjectMemberRequestDTO);
 

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberService.java
@@ -3,7 +3,7 @@ package org.omoknoone.ppm.domain.projectmember.service;
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMember;
 import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
-import org.omoknoone.ppm.domain.projectmember.dto.ViewAvailableMemberResponseDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewAvailableMembersResponseDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO;
 
 import java.util.List;
@@ -12,17 +12,17 @@ public interface ProjectMemberService {
 
     List<ViewProjectMembersByProjectResponseDTO> viewProjectMembersByProject(Integer projectMemberProjectId);
 
-    List<ViewAvailableMemberResponseDTO> viewAndSearchAvailableMembers(Integer projectMemberProjectId, String query);
+    List<ViewAvailableMembersResponseDTO> viewAndSearchAvailableMembers(Integer projectId, String query);
 
     Integer createProjectMember(CreateProjectMemberRequestDTO createProjectMemberRequestDTO);
 
     void removeProjectMember(ModifyProjectMemberRequestDTO projectMemberId);
 
-    void reactivateProjectMember(ModifyProjectMemberRequestDTO projectMemberId);
+//    void reactivateProjectMember(ModifyProjectMemberRequestDTO projectMemberId);
 
-    Integer modifyProjectMember(ModifyProjectMemberRequestDTO modifyProjectMemberRequestDTO);
+//    Integer modifyProjectMember(ModifyProjectMemberRequestDTO modifyProjectMemberRequestDTO);
 
-    Integer viewProjectMemberId(String employeeId, Integer projectId);
+//    Integer viewProjectMemberId(String employeeId, Integer projectId);
 
-    List<ProjectMember> viewProjectMemberListByEmployeeId(String employeeId);
+//    List<ProjectMember> viewProjectMemberListByEmployeeId(String employeeId);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/service/ProjectMemberServiceImpl.java
@@ -9,7 +9,8 @@ import org.omoknoone.ppm.domain.permission.service.PermissionService;
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMember;
 import org.omoknoone.ppm.domain.projectmember.dto.CreateProjectMemberRequestDTO;
 import org.omoknoone.ppm.domain.projectmember.dto.ModifyProjectMemberRequestDTO;
-import org.omoknoone.ppm.domain.projectmember.dto.viewProjectMembersByProjectResponseDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewAvailableMemberResponseDTO;
+import org.omoknoone.ppm.domain.projectmember.dto.ViewProjectMembersByProjectResponseDTO;
 import org.omoknoone.ppm.domain.projectmember.repository.ProjectMemberRepository;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
@@ -31,13 +32,18 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<viewProjectMembersByProjectResponseDTO> viewProjectMembersByProject(Integer projectMemberProjectId) {
+    public List<ViewProjectMembersByProjectResponseDTO> viewProjectMembersByProject(Integer projectMemberProjectId) {
 
         List<ProjectMember> projectMembers = projectMemberRepository.findByProjectMemberProjectId(projectMemberProjectId);
 
         return projectMembers.stream()
-                .map(member -> modelMapper.map(member, viewProjectMembersByProjectResponseDTO.class))
+                .map(member -> modelMapper.map(member, ViewProjectMembersByProjectResponseDTO.class))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ViewAvailableMemberResponseDTO> viewAndSearchAvailableMembers(Integer projectMemberProjectId, String query) {
+        return List.of();
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈
- #21 
- #158 


## 📝작업 내용

> - 프로젝트 구성원 추가 목록 조회 기능을 이름 검색을 통한 조회, 검색을 하지 않는 경우에는 해당 프로젝트 기준 추가 될 수 있는 구성원이 추가될 수 있도록 코드를 개선했습니다.
> - 프로젝트 구성원을 조회할 때, employee, permission의 필드값을 가져올 수 있도록 개선하였습니다. permission 부분은 추가 점검 및 테스트를 통해 동작 여부를 확인 예정입니다.
>  - 프로젝트 구성원의 참여일과 제외일을 한 쌍으로 관리 하는 내역으로 변경했습니다. 만약 같은 프로젝트에서 특정 구성원이 추가 및 제외 되고 다시 추가가 된다면 projectMemberHistoryId 생성 되면서 새로운 행에 추가일과 제외일이 관리됩니다.

### 📷스크린샷 (선택)
- 


## 💬리뷰 요구사항(선택)
-
