### PR TITLE
[PR] 금주, 차주 일정 조회 기능

### DIFF
--- a/src/main/java/org/omoknoone/ppm/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/notification/service/NotificationServiceImpl.java
@@ -26,6 +26,7 @@ import org.omoknoone.ppm.domain.permission.service.PermissionServiceImpl;
 import org.omoknoone.ppm.domain.project.service.ProjectServiceImpl;
 import org.omoknoone.ppm.domain.projectmember.aggregate.ProjectMember;
 import org.omoknoone.ppm.domain.projectmember.repository.ProjectMemberRepository;
+import org.omoknoone.ppm.domain.schedule.dto.FindSchedulesForWeekDTO;
 import org.omoknoone.ppm.domain.schedule.dto.ScheduleDTO;
 import org.omoknoone.ppm.domain.schedule.service.ScheduleServiceCalculator;
 import org.omoknoone.ppm.domain.schedule.service.ScheduleServiceImpl;
@@ -78,7 +79,7 @@ public class NotificationServiceImpl implements NotificationService {
     @Transactional
     public void checkConditionsAndSendNotifications(Integer projectId) {
         int alarm = scheduleServiceImpl.calculateRatioThisWeek(projectId);
-        List<ScheduleDTO> schedules = scheduleServiceImpl.getSchedulesForThisWeek(projectId);
+        List<FindSchedulesForWeekDTO> schedules = scheduleServiceImpl.getSchedulesForThisWeek(projectId);
         String projectTitle = projectServiceImpl.getProjectTitleById(projectId);
         List<ProjectMember> projectMembers = projectMemberRepository.findByProjectMemberProjectId(projectId);
 
@@ -87,7 +88,7 @@ public class NotificationServiceImpl implements NotificationService {
         }
     }
 
-    private void handleNotificationsForMember(ProjectMember member, List<ScheduleDTO> schedules, String projectTitle, int alarm) {
+    private void handleNotificationsForMember(ProjectMember member, List<FindSchedulesForWeekDTO> schedules, String projectTitle, int alarm) {
         boolean isPm = permissionServiceImpl.hasPmRole(Long.valueOf(member.getProjectMemberId()));
         boolean isDev = stakeholdersServiceImpl.hasDevRole(Long.valueOf(member.getProjectMemberId()));
 
@@ -103,13 +104,13 @@ public class NotificationServiceImpl implements NotificationService {
         }
     }
 
-    private List<ScheduleDTO> getIncompleteSchedulesForMember(List<ScheduleDTO> schedules, ProjectMember member) {
+    private List<FindSchedulesForWeekDTO> getIncompleteSchedulesForMember(List<FindSchedulesForWeekDTO> schedules, ProjectMember member) {
         return schedules.stream()
             .filter(schedule -> isScheduleIncompleteForMember(schedule, member))
             .toList();
     }
 
-    private boolean isScheduleIncompleteForMember(ScheduleDTO schedule, ProjectMember member) {
+    private boolean isScheduleIncompleteForMember(FindSchedulesForWeekDTO schedule, ProjectMember member) {
         List<Stakeholders> stakeholders = stakeholdersServiceImpl.findByScheduleId(schedule.getScheduleId());
         return stakeholders.stream().anyMatch(stakeholder ->
             stakeholder.getProjectMemberId().equals(Long.valueOf(member.getProjectMemberId())) && !isCompleted(schedule, commonCodeRepository));
@@ -243,7 +244,7 @@ public class NotificationServiceImpl implements NotificationService {
             .replace("{notificationContent}", notification.getNotificationContent());
     }
 
-    private boolean isCompleted(ScheduleDTO schedule, CommonCodeRepository commonCodeRepository) {
+    private boolean isCompleted(FindSchedulesForWeekDTO schedule, CommonCodeRepository commonCodeRepository) {
         String status = schedule.getScheduleStatus();
         String scheduleCompleted = commonCodeRepository.findById(ScheduleServiceCalculator.schedule_completed)
             .map(CommonCode::getCodeName)

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/controller/ScheduleController.java
@@ -13,10 +13,7 @@ import org.omoknoone.ppm.common.HttpHeadersCreator;
 import org.omoknoone.ppm.common.ResponseMessage;
 import org.omoknoone.ppm.domain.project.service.ProjectService;
 import org.omoknoone.ppm.domain.schedule.aggregate.Schedule;
-import org.omoknoone.ppm.domain.schedule.dto.CreateScheduleDTO;
-import org.omoknoone.ppm.domain.schedule.dto.RequestModifyScheduleDTO;
-import org.omoknoone.ppm.domain.schedule.dto.ScheduleDTO;
-import org.omoknoone.ppm.domain.schedule.dto.SearchScheduleListDTO;
+import org.omoknoone.ppm.domain.schedule.dto.*;
 import org.omoknoone.ppm.domain.schedule.service.ScheduleService;
 import org.omoknoone.ppm.domain.schedule.vo.RequestSchedule;
 import org.omoknoone.ppm.domain.schedule.vo.ResponseSchedule;
@@ -280,7 +277,7 @@ public class ScheduleController {
 
         HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
-        List<ScheduleDTO> schedules = scheduleService.getSchedulesForThisWeek(projectId);
+        List<FindSchedulesForWeekDTO> schedules = scheduleService.getSchedulesForThisWeek(projectId);
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("findSchedulesForThisWeek", schedules);
@@ -293,11 +290,11 @@ public class ScheduleController {
 
     /* 해당 날짜 기준으로 차주에 끝나야 할 일정 목록 조회 */
     @GetMapping("/nextweek/{projectId}")
-    public ResponseEntity<ResponseMessage> findSchedulesForNextWeek(Integer projectId){
+    public ResponseEntity<ResponseMessage> findSchedulesForNextWeek(@PathVariable Integer projectId){
 
         HttpHeaders headers = HttpHeadersCreator.createHeaders();
 
-        List<ScheduleDTO> schedules = scheduleService.getSchedulesForNextWeek(projectId);
+        List<FindSchedulesForWeekDTO> schedules = scheduleService.getSchedulesForNextWeek(projectId);
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("findSchedulesForNextWeek", schedules);

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/dto/FindSchedulesForWeekDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/dto/FindSchedulesForWeekDTO.java
@@ -1,0 +1,48 @@
+package org.omoknoone.ppm.domain.schedule.dto;
+
+import lombok.*;
+import org.omoknoone.ppm.domain.schedule.aggregate.Schedule;
+import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersDTO;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * DTO for {@link Schedule}
+ */
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class FindSchedulesForWeekDTO {
+    private Long scheduleId;
+    private String scheduleTitle;
+    private String scheduleContent;
+    private LocalDate scheduleStartDate;
+    private LocalDate scheduleEndDate;
+    private String scheduleStatus;
+    private Boolean scheduleIsDeleted;
+    private Long scheduleProjectId;
+
+    // 작성자
+    private String authorId;
+    private String authorName;
+
+    // 담당자
+    private List<StakeholdersDTO> assigneeList;
+
+    @Builder
+    public FindSchedulesForWeekDTO(Long scheduleId, String scheduleTitle, String scheduleContent, LocalDate scheduleStartDate, LocalDate scheduleEndDate, String scheduleStatus, Boolean scheduleIsDeleted, Long scheduleProjectId, String authorId, String authorName, List<StakeholdersDTO> assigneeList) {
+        this.scheduleId = scheduleId;
+        this.scheduleTitle = scheduleTitle;
+        this.scheduleContent = scheduleContent;
+        this.scheduleStartDate = scheduleStartDate;
+        this.scheduleEndDate = scheduleEndDate;
+        this.scheduleStatus = scheduleStatus;
+        this.scheduleIsDeleted = scheduleIsDeleted;
+        this.scheduleProjectId = scheduleProjectId;
+        this.authorId = authorId;
+        this.authorName = authorName;
+        this.assigneeList = assigneeList;
+    }
+}

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/dto/FindSchedulesForWeekDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/dto/FindSchedulesForWeekDTO.java
@@ -3,6 +3,7 @@ package org.omoknoone.ppm.domain.schedule.dto;
 import lombok.*;
 import org.omoknoone.ppm.domain.schedule.aggregate.Schedule;
 import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersDTO;
+import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -29,10 +30,10 @@ public class FindSchedulesForWeekDTO {
     private String authorName;
 
     // 담당자
-    private List<StakeholdersDTO> assigneeList;
+    private List<StakeholdersEmployeeInfoDTO> assigneeList;
 
     @Builder
-    public FindSchedulesForWeekDTO(Long scheduleId, String scheduleTitle, String scheduleContent, LocalDate scheduleStartDate, LocalDate scheduleEndDate, String scheduleStatus, Boolean scheduleIsDeleted, Long scheduleProjectId, String authorId, String authorName, List<StakeholdersDTO> assigneeList) {
+    public FindSchedulesForWeekDTO(Long scheduleId, String scheduleTitle, String scheduleContent, LocalDate scheduleStartDate, LocalDate scheduleEndDate, String scheduleStatus, Boolean scheduleIsDeleted, Long scheduleProjectId, String authorId, String authorName, List<StakeholdersEmployeeInfoDTO> assigneeList) {
         this.scheduleId = scheduleId;
         this.scheduleTitle = scheduleTitle;
         this.scheduleContent = scheduleContent;

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/repository/ScheduleRepository.java
@@ -102,25 +102,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findSchedulesByDateRange(@Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate);
 
-    /* 해당 일자가 포함된 주에 끝나야할 일정 목록 조회 */
-    @Query("SELECT new org.omoknoone.ppm.domain.schedule.dto.ScheduleDTO" +
-        "(s.scheduleId, s.scheduleTitle, s.scheduleContent, s.scheduleStartDate" +
-        ", s.scheduleEndDate, s.scheduleDepth, s.schedulePriority, s.scheduleProgress" +
-        ", CAST(s.scheduleStatus AS string), s.scheduleManHours, s.scheduleParentScheduleId, s.schedulePrecedingScheduleId" +
-        ", s.scheduleCreatedDate, s.scheduleModifiedDate, s.scheduleIsDeleted" +
-        ", s.scheduleDeletedDate, s.scheduleProjectId) " +
-        "FROM Schedule s " +
-        "WHERE s.scheduleEndDate >= :thisMonday AND s.scheduleEndDate <= :thisSunday")
-    List<ScheduleDTO> getSchedulesForThisWeek(@Param("thisMonday") LocalDate thisMonday, @Param("thisSunday") LocalDate thisSunday);
-
-    /* 해당 일자 기준으로 차주에 끝나야할 일정 목록 조회 */
-    @Query("SELECT new org.omoknoone.ppm.domain.schedule.dto.ScheduleDTO" +
-        "(s.scheduleId, s.scheduleTitle, s.scheduleContent, s.scheduleStartDate" +
-        ", s.scheduleEndDate, s.scheduleDepth, s.schedulePriority, s.scheduleProgress" +
-        ", CAST(s.scheduleStatus AS string), s.scheduleManHours, s.scheduleParentScheduleId, s.schedulePrecedingScheduleId" +
-        ", s.scheduleCreatedDate, s.scheduleModifiedDate, s.scheduleIsDeleted" +
-        ", s.scheduleDeletedDate, s.scheduleProjectId) " +
-        "FROM Schedule s " +
-        "WHERE s.scheduleEndDate >= :NextMonday AND s.scheduleEndDate <= :NextSunday")
-    List<ScheduleDTO> getSchedulesForNextWeek(@Param("NextMonday") LocalDate NextMonday, @Param("NextSunday") LocalDate NextSunday);
+    /* 해당 일자가 포함된 주에 끝나야 할 일정 목록 조회 */
+    List<Schedule> findByScheduleEndDateBetweenAndScheduleIsDeletedFalse(@Param("monday") LocalDate monday, @Param("sunday") LocalDate sunday);
 }

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleService.java
@@ -5,13 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.omoknoone.ppm.domain.schedule.aggregate.Schedule;
-import org.omoknoone.ppm.domain.schedule.dto.CreateScheduleDTO;
-import org.omoknoone.ppm.domain.schedule.dto.ModifyScheduleDateDTO;
-import org.omoknoone.ppm.domain.schedule.dto.ModifyScheduleProgressDTO;
-import org.omoknoone.ppm.domain.schedule.dto.ModifyScheduleTitleAndContentDTO;
-import org.omoknoone.ppm.domain.schedule.dto.RequestModifyScheduleDTO;
-import org.omoknoone.ppm.domain.schedule.dto.ScheduleDTO;
-import org.omoknoone.ppm.domain.schedule.dto.SearchScheduleListDTO;
+import org.omoknoone.ppm.domain.schedule.dto.*;
 import org.omoknoone.ppm.domain.schedule.vo.ResponseScheduleSheetData;
 
 public interface ScheduleService {
@@ -73,10 +67,10 @@ public interface ScheduleService {
     List<ScheduleDTO> viewSchedulesByDateRange(LocalDate startDate, LocalDate endDate);
 
     /* 해당 일자가 포함된 주에 끝나야할 일정 목록 조회 */
-    List<ScheduleDTO> getSchedulesForThisWeek(Integer projectId);
+    List<FindSchedulesForWeekDTO> getSchedulesForThisWeek(Integer projectId);
 
     /* 해당 일자 기준으로 차주에 끝나야할 일정 목록 조회 */
-	List<ScheduleDTO> getSchedulesForNextWeek(Integer projectId);
+    List<FindSchedulesForWeekDTO> getSchedulesForNextWeek(Integer projectId);
 
     /* 구간별 일정 예상 누적 진행률 */
     int[] calculateScheduleRatios(LocalDate startDate, LocalDate endDate);

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceCalculator.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceCalculator.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import org.omoknoone.ppm.domain.commoncode.aggregate.CommonCode;
 import org.omoknoone.ppm.domain.commoncode.repository.CommonCodeRepository;
 import org.omoknoone.ppm.domain.notification.service.NotificationScheduler;
+import org.omoknoone.ppm.domain.schedule.dto.FindSchedulesForWeekDTO;
 import org.omoknoone.ppm.domain.schedule.dto.ScheduleDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,13 +20,13 @@ public class ScheduleServiceCalculator {
 	private static final Long schedule_in_progress = 10302L;
 	public static final Long schedule_completed = 10303L;
 
-	public static int calculateReadyOrInProgressRatio(List<ScheduleDTO> schedules, CommonCodeRepository commonCodeRepository) {
+	public static int calculateReadyOrInProgressRatio(List<FindSchedulesForWeekDTO> schedules, CommonCodeRepository commonCodeRepository) {
 		if (schedules == null || schedules.isEmpty()) {
 			return 0;
 		}
 
 		int countReadyOrInProgress = 0;
-		for (ScheduleDTO schedule : schedules) {
+		for (FindSchedulesForWeekDTO schedule : schedules) {
 			if (isReadyOrInProgress(schedule, commonCodeRepository)) {
 				countReadyOrInProgress++;
 			}
@@ -38,7 +39,7 @@ public class ScheduleServiceCalculator {
 		return (int) Math.round(ratio);
 	}
 
-	private static boolean isReadyOrInProgress(ScheduleDTO schedule, CommonCodeRepository commonCodeRepository) {
+	private static boolean isReadyOrInProgress(FindSchedulesForWeekDTO schedule, CommonCodeRepository commonCodeRepository) {
 		String status = schedule.getScheduleStatus();
 		String scheduleReady = commonCodeRepository.findById(schedule_ready)
 			.map(CommonCode::getCodeName)

--- a/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/schedule/service/ScheduleServiceImpl.java
@@ -1,20 +1,5 @@
 package org.omoknoone.ppm.domain.schedule.service;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
-
-import lombok.RequiredArgsConstructor;
-
 import org.jetbrains.annotations.NotNull;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
@@ -35,6 +20,12 @@ import org.omoknoone.ppm.domain.stakeholders.service.StakeholdersService;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.*;
+import java.util.stream.Collectors;
 
 //@RequiredArgsConstructor
 @Service

--- a/src/main/java/org/omoknoone/ppm/domain/stakeholders/dto/StakeholdersEmployeeInfoDTO.java
+++ b/src/main/java/org/omoknoone/ppm/domain/stakeholders/dto/StakeholdersEmployeeInfoDTO.java
@@ -1,8 +1,5 @@
 package org.omoknoone.ppm.domain.stakeholders.dto;
 
-import java.io.Serializable;
-import java.time.LocalDateTime;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +14,7 @@ public class StakeholdersEmployeeInfoDTO {
     Long stakeholdersId;
     Long stakeholdersType;
     Long stakeholdersScheduleId;
-    Long ProjectMemberId;
+    Long projectMemberId;
     String employeeId;
     String employeeName;
 
@@ -27,7 +24,7 @@ public class StakeholdersEmployeeInfoDTO {
         this.stakeholdersId = stakeholdersId;
         this.stakeholdersType = stakeholdersType;
         this.stakeholdersScheduleId = stakeholdersScheduleId;
-        ProjectMemberId = projectMemberId;
+        this.projectMemberId = projectMemberId;
         this.employeeId = employeeId;
         this.employeeName = employeeName;
     }

--- a/src/main/java/org/omoknoone/ppm/domain/stakeholders/repository/StakeholdersRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/stakeholders/repository/StakeholdersRepository.java
@@ -2,13 +2,10 @@ package org.omoknoone.ppm.domain.stakeholders.repository;
 
 import org.omoknoone.ppm.domain.stakeholders.aggregate.Stakeholders;
 import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersDTO;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -20,7 +17,7 @@ public interface StakeholdersRepository extends JpaRepository<Stakeholders, Long
 	@Query("SELECT new org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersDTO(s.stakeholdersId, s.stakeholdersType, s.stakeholdersScheduleId, s.stakeholdersProjectMemberId) " +
 		"FROM Stakeholders s WHERE s.stakeholdersProjectMemberId = :stakeholdersProjectMemberId")
 	List<StakeholdersDTO> findByStakeholdersProjectMemberId(@Param("stakeholdersProjectMemberId") Long stakeholdersProjectMemberId);
-}
+
 
     @Query("SELECT new org.omoknoone.ppm.domain.stakeholders.dto.StakeholdersEmployeeInfoDTO("
         + " st.stakeholdersId, st.stakeholdersType, st.stakeholdersScheduleId, "

--- a/src/main/java/org/omoknoone/ppm/domain/stakeholders/service/StakeholdersServiceImpl.java
+++ b/src/main/java/org/omoknoone/ppm/domain/stakeholders/service/StakeholdersServiceImpl.java
@@ -92,6 +92,7 @@ public class StakeholdersServiceImpl implements StakeholdersService {
 
     public List<Stakeholders> findByScheduleId(Long scheduleId) {
         return stakeholdersRepository.findStakeholdersByStakeholdersScheduleId(scheduleId);
+    }
 
     @Override
     public List<StakeholdersEmployeeInfoDTO> viewStakeholdersEmployeeInfo(Long[] scheduleIdList) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #130 

## 📝작업 내용

> 금주, 차주 일정 조회 기능 구현
- 금주, 차주에 종료되어야 할 일정들 상태 모아보기
- 일정에 대한 정보, 작성자 정보, 담당자 정보, 일정의 상태

### 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 현근님에게 `ScheduleDTO`를  `FindSchedulesForWeekDTO`로 바꿔도 된다고 하여 바꿨는데 다른 곳에 영향이 갈 수도 있습니다