### PR TITLE
[PR] 프로젝트 구성원 추가 리스트에서 admin 계정은 목록에 추가 되지 않도록 수정

### DIFF
--- a/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/omoknoone/ppm/domain/projectmember/repository/ProjectMemberRepository.java
@@ -17,7 +17,9 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, In
             "JOIN Employee e ON pm.projectMemberEmployeeId = e.employeeId " +
             "LEFT JOIN CommonCode cc ON cc.codeId = pm.projectMemberRoleId " +
             "WHERE pm.projectMemberProjectId = :projectId" +
-            " AND pm.projectMemberIsExcluded = false")
+            " AND pm.projectMemberIsExcluded = false" +
+            " AND e.employeeRole <> 'ROLE_ADMIN'")
+    
     List<ViewProjectMembersByProjectResponseDTO> findByProjectMembersProjectId(@Param("projectId") Integer projectId);
 
     ProjectMember findByProjectMemberEmployeeIdAndProjectMemberProjectId(String employeeId, Integer projectId);


### PR DESCRIPTION
## #️⃣연관된 이슈

- #198 

## 📝작업 내용

> 프로젝트 구성원 추가 리스트에서 admin 계정이 보이는 이슈가 발생하여 보이지 않도록 코드를 수정합니다.

