### PR TITLE
[PR] 홈서버 이전에 따른 설정 변경

### DIFF
--- a/src/main/java/org/omoknoone/ppm/config/WebConfig.java
+++ b/src/main/java/org/omoknoone/ppm/config/WebConfig.java
@@ -15,7 +15,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins(
                         "http://localhost/",
-                        "http://192.168.0.4/",
+                        "http://192.168.0.10/",
                         "http://ppmppm.site/",
                         "http://www.ppmppm.site/",
                         "https://api.nepcha.com/",

--- a/src/main/java/org/omoknoone/ppm/config/WebConfig.java
+++ b/src/main/java/org/omoknoone/ppm/config/WebConfig.java
@@ -15,7 +15,6 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins(
                         "http://localhost/",
-                        "http://192.168.0.4/",
                         "http://ppmppm.site/",
                         "http://www.ppmppm.site/",
                         "https://api.nepcha.com/",

--- a/src/main/java/org/omoknoone/ppm/config/WebConfig.java
+++ b/src/main/java/org/omoknoone/ppm/config/WebConfig.java
@@ -14,6 +14,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins(
+                        "http://localhost/",
                         "http://ppmppm.site/",
                         "http://www.ppmppm.site/",
                         "https://api.nepcha.com/",

--- a/src/main/java/org/omoknoone/ppm/config/WebConfig.java
+++ b/src/main/java/org/omoknoone/ppm/config/WebConfig.java
@@ -15,6 +15,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins(
                         "http://localhost/",
+                        "http://192.168.0.4/",
                         "http://ppmppm.site/",
                         "http://www.ppmppm.site/",
                         "https://api.nepcha.com/",

--- a/src/main/java/org/omoknoone/ppm/security/CorsConfig.java
+++ b/src/main/java/org/omoknoone/ppm/security/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(List.of("http://ppmppm.site/", "http://www.ppmppm.site/",
+        config.setAllowedOrigins(List.of("http://ppmppm.site/", "http://www.ppmppm.site/", "http://localhost/",
                 "http://a8237ef3f9cb34681a23bbeb7ecb13c1-632214019.ap-northeast-2.elb.amazonaws.com/",
                 "http://www.a8237ef3f9cb34681a23bbeb7ecb13c1-632214019.ap-northeast-2.elb.amazonaws.com/",
                 "https://api.nepcha.com/",

--- a/src/main/java/org/omoknoone/ppm/security/CorsConfig.java
+++ b/src/main/java/org/omoknoone/ppm/security/CorsConfig.java
@@ -18,7 +18,6 @@ public class CorsConfig {
 
         config.setAllowCredentials(true);
         config.setAllowedOrigins(List.of("http://ppmppm.site/", "http://www.ppmppm.site/", "http://localhost/",
-                "http://192.168.0.4/",
                 "http://a8237ef3f9cb34681a23bbeb7ecb13c1-632214019.ap-northeast-2.elb.amazonaws.com/",
                 "http://www.a8237ef3f9cb34681a23bbeb7ecb13c1-632214019.ap-northeast-2.elb.amazonaws.com/",
                 "https://api.nepcha.com/",

--- a/src/main/java/org/omoknoone/ppm/security/CorsConfig.java
+++ b/src/main/java/org/omoknoone/ppm/security/CorsConfig.java
@@ -18,7 +18,7 @@ public class CorsConfig {
 
         config.setAllowCredentials(true);
         config.setAllowedOrigins(List.of("http://ppmppm.site/", "http://www.ppmppm.site/", "http://localhost/",
-                "http://192.168.0.4/",
+                "http://192.168.0.10/",
                 "http://a8237ef3f9cb34681a23bbeb7ecb13c1-632214019.ap-northeast-2.elb.amazonaws.com/",
                 "http://www.a8237ef3f9cb34681a23bbeb7ecb13c1-632214019.ap-northeast-2.elb.amazonaws.com/",
                 "https://api.nepcha.com/",

--- a/src/main/java/org/omoknoone/ppm/security/CorsConfig.java
+++ b/src/main/java/org/omoknoone/ppm/security/CorsConfig.java
@@ -18,6 +18,7 @@ public class CorsConfig {
 
         config.setAllowCredentials(true);
         config.setAllowedOrigins(List.of("http://ppmppm.site/", "http://www.ppmppm.site/", "http://localhost/",
+                "http://192.168.0.4/",
                 "http://a8237ef3f9cb34681a23bbeb7ecb13c1-632214019.ap-northeast-2.elb.amazonaws.com/",
                 "http://www.a8237ef3f9cb34681a23bbeb7ecb13c1-632214019.ap-northeast-2.elb.amazonaws.com/",
                 "https://api.nepcha.com/",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
     name: PPM-Backend
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: ENC(h3SQfSBcw2qduGjOeZWQYHJo3xy9/OJFgxPtpkuIzlG15uauPd5yEIiALKO3q86jJKvGGfeiGwycpXEglaE81vOOH03SncNDiMjBWj0bXg2m5vpInoR6PQ==)
-    username: ENC(y4pO3gmaIJRIC+35NstrKvCqmlYdTuyd)
-    password: ENC(CvjcCWcM/jtWMznsBfJw6sioFNZI9xYS)
+    url: ENC(EdH0MIpoZaUfhSFb6GSM9ZtJYkkuLmIjIajt3ulR65h1nNJMTp11GjaVhwbOBpUG)
+    username: ENC(MsRZrKdcjys7PXAPIHHh4kqM0m21nKN3)
+    password: ENC(VDnFwY1e2YpDofHSnRcMTX4SkpRfifag)
   config:
     import:
       - classpath:/messages.yml


### PR DESCRIPTION
## #️⃣연관된 이슈

- #232 

## 📝작업 내용

> 개인 노트북(항시 ON)에 Ubuntu를 설치하여 서버가 돌아가게 설정
- 가비아 DNS 설정은 하였으나 아직 적용이 되지 않은 것으로 보임
- RDS 대신 노트북에 설치한 mariadb 주소로 변경
- 자세한 정보들은 slack으로 공유

### 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
